### PR TITLE
Override (disable) all target optimization options.

### DIFF
--- a/Language/Haskell/GhcMod/Target.hs
+++ b/Language/Haskell/GhcMod/Target.hs
@@ -144,7 +144,7 @@ runGmlTWith efnmns' mdf wrapper action = do
         serfnmn = Set.fromList $ map Right mns ++ map Left rfns
 
     opts <- targetGhcOptions crdl serfnmn
-    let opts' = opts ++ ghcUserOptions
+    let opts' = opts ++ ["-O0"] ++ ghcUserOptions
 
     initSession opts' $
         setModeSimple >>> setEmptyLogger >>> mdf


### PR DESCRIPTION
User specified options can still be used to enable some optimizations if
really needed.