### PR TITLE
Various improvements and fixes of elisp and haskell

### DIFF
--- a/Language/Haskell/GhcMod/Target.hs
+++ b/Language/Haskell/GhcMod/Target.hs
@@ -18,7 +18,7 @@
 module Language.Haskell.GhcMod.Target where
 
 import Control.Arrow
-import Control.Applicative ((<$>))
+import Control.Applicative (Applicative, (<$>))
 import Control.Monad.Reader (runReaderT)
 import GHC
 import GHC.Paths (libdir)
@@ -257,11 +257,11 @@ findCandidates scns = foldl1 Set.intersection scns
 pickComponent :: Set ChComponentName -> ChComponentName
 pickComponent scn = Set.findMin scn
 
-packageGhcOptions :: (MonadIO m, GmEnv m, GmLog m) => m [GHCOption]
+packageGhcOptions :: (Applicative m, MonadIO m, GmEnv m, GmLog m) => m [GHCOption]
 packageGhcOptions = do
     crdl <- cradle
     case cradleCabalFile crdl of
-      Just _ -> do
+      Just _ ->
         (Set.toList . Set.fromList . concat . map snd) `liftM` getGhcPkgOptions
       Nothing -> sandboxOpts crdl
 

--- a/Language/Haskell/GhcMod/Target.hs
+++ b/Language/Haskell/GhcMod/Target.hs
@@ -37,10 +37,8 @@ import Language.Haskell.GhcMod.GhcPkg
 import Language.Haskell.GhcMod.Error
 import Language.Haskell.GhcMod.Logging
 import Language.Haskell.GhcMod.Types
-import Language.Haskell.GhcMod.Utils
 
 import Data.Maybe
-import Data.Monoid
 import Data.Either
 import Data.Foldable (foldrM)
 import Data.Traversable (traverse)
@@ -315,7 +313,7 @@ resolveModule :: MonadIO m =>
 resolveModule env _srcDirs (Right mn) =
     liftIO $ traverse canonicalizeModulePath =<< findModulePath env mn
 resolveModule env srcDirs (Left fn') = liftIO $ do
-    mfn <- findFile' srcDirs fn'
+    mfn <- findFile srcDirs fn'
     case mfn of
       Nothing -> return Nothing
       Just fn'' -> do
@@ -327,9 +325,6 @@ resolveModule env srcDirs (Left fn') = liftIO $ do
                   case mmn of
                     Nothing -> mkMainModulePath fn
                     Just mn -> ModulePath mn fn
- where
-   findFile' dirs file =
-       getFirst . mconcat <$> mapM (fmap First . mightExist . (</>file)) dirs
 
 resolveChEntrypoints ::
   FilePath -> ChEntrypoint -> IO [Either FilePath ModuleName]
@@ -365,7 +360,6 @@ resolveGmComponents mumns cs = do
                        else insertUpdated m c
     gmsPut s { gmComponents = m' }
     return m'
-
  where
    foldrM' b fa f = foldrM f b fa
    insertUpdated m c = do

--- a/Language/Haskell/GhcMod/Target.hs
+++ b/Language/Haskell/GhcMod/Target.hs
@@ -181,7 +181,7 @@ targetGhcOptions crdl sefnmn = do
 
        if noCandidates && noModuleHasAnyAssignment
           then do
-            gmLog GmWarning "" $ strDoc $ "Could not find a componenet assignment, falling back to sandbox only project options."
+            gmLog GmWarning "" $ strDoc $ "Could not find a component assignment, falling back to sandbox only project options."
             sandboxOpts crdl
           else do
             when noCandidates $

--- a/elisp/ghc-process.el
+++ b/elisp/ghc-process.el
@@ -18,7 +18,8 @@
 (defvar-local ghc-process-original-buffer nil)
 (defvar-local ghc-process-original-file nil)
 (defvar-local ghc-process-callback nil)
-(defvar-local ghc-process-hook nil)
+(defvar-local ghc-process-hook nil
+  "Hook that will be called upon successfull completion of ghc-mod command.")
 
 (defvar ghc-command "ghc-mod")
 
@@ -30,26 +31,28 @@
 (defun ghc-with-process (cmd callback &optional hook1 hook2)
   (unless ghc-process-process-name
     (setq ghc-process-process-name (ghc-get-project-root)))
-  (when (and ghc-process-process-name (not ghc-process-running))
-    (setq ghc-process-running t)
-    (if hook1 (funcall hook1))
-    (let* ((cbuf (current-buffer))
-	   (name ghc-process-process-name)
-	   (buf (get-buffer-create (concat " ghc-mod:" name)))
-	   (file (buffer-file-name))
-	   (cpro (get-process name)))
-      (ghc-with-current-buffer buf
-        (setq ghc-process-original-buffer cbuf)
-	(setq ghc-process-original-file file)
-	(setq ghc-process-callback callback)
-	(setq ghc-process-hook hook2)
-	(erase-buffer)
-	(let ((pro (ghc-get-process cpro name buf)))
-	  (process-send-string pro cmd)
-	  (when ghc-debug
-	    (ghc-with-debug-buffer
-	     (insert (format "%% %s" cmd))))
-	  pro)))))
+  (if ghc-process-running
+    (error "ghc process already running")
+    (progn
+      (when ghc-process-running t)
+      (if hook1 (funcall hook1))
+      (let* ((cbuf (current-buffer))
+             (name ghc-process-process-name)
+             (buf (get-buffer-create (concat " ghc-mod:" name)))
+             (file (buffer-file-name))
+             (cpro (get-process name)))
+        (ghc-with-current-buffer buf
+          (setq ghc-process-original-buffer cbuf)
+          (setq ghc-process-original-file file)
+          (setq ghc-process-callback callback)
+          (setq ghc-process-hook hook2)
+          (erase-buffer)
+          (let ((pro (ghc-get-process cpro name buf)))
+            (process-send-string pro cmd)
+            (when ghc-debug
+              (ghc-with-debug-buffer
+               (insert (format "%% %s" cmd))))
+            pro))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Most obscure change, in my opinion, is the need to supply "legacy-interactive" argument in elisp at the end of other arguments. Otherwise other arguments, like `-s` are dropped due to `RequireOrder` semantics - https://hackage.haskell.org/package/base-4.8.0.0/docs/System-Console-GetOpt.html#v:RequireOrder. The "legacy-interactive" argument is being treated as non-option and this suppresses parsing of any options next on command line.

Change of `ghc-with-process` to bark if ghc process is already running, according to `ghc-process-running` variable, is useful when debugging. It may be a bit intrusive, though, as previously it didn't print any messages. But I think it may be equally bad to silently exit and keep unsuspecting user thinking that something is being executed.

Other commits should be, hopefully, self-explanatory.