### PR TITLE
Update stack to lts-3.1 resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ packages:
 - '.'
 extra-deps:
 - cabal-helper-0.5.1.0
-resolver: lts-3.0
+resolver: lts-3.1


### PR DESCRIPTION
It compiles just fine with the latest stack lts so I guess it is safe to update ?
