### PR TITLE
Fix path environment variable lookup (#593) on Windows

### DIFF
--- a/Language/Haskell/GhcMod/PathsAndFiles.hs
+++ b/Language/Haskell/GhcMod/PathsAndFiles.hs
@@ -33,6 +33,7 @@ import Data.Maybe
 import Data.Traversable hiding (mapM)
 import Distribution.Helper (buildPlatform)
 import System.Directory
+import System.Environment
 import System.FilePath
 import System.Process
 import System.Info.Extra
@@ -89,10 +90,11 @@ findStackConfigFile dir = do
 getStackEnv :: (IOish m, GmOut m) => FilePath -> m (Maybe StackEnv)
 getStackEnv projdir = U.withDirectory_ projdir $ runMaybeT $ do
     env <- map (liToTup . splitOn ": ") . lines <$> readStack ["path"]
+    pathEnvVar <- MaybeT $ liftIO $ lookupEnv "path"
     let look k = fromJust $ lookup k env
     return StackEnv {
         seDistDir       = look "dist-dir"
-      , seBinPath       = splitSearchPath $ look "bin-path"
+      , seBinPath       = splitSearchPath pathEnvVar
       , seSnapshotPkgDb = look "snapshot-pkg-db"
       , seLocalPkgDb    = look "local-pkg-db"
       }


### PR DESCRIPTION
It didn't work on Windows because stack would incorrectly return the paths separated with a ':' char instead of ';' (Windows standard). ':' also conflicts with drive letter separators, e.g. 'C:\Windows'.

Since we are doing the splitting using splitSearchPath, it makes sense to do the environment variable lookup ourselves anyway.

This still needs testing on Linux and Mac, which I can't do myself.
