### PR TITLE
Fixed #561

### DIFF
--- a/elisp/ghc-check.el
+++ b/elisp/ghc-check.el
@@ -165,17 +165,12 @@ nil            do not display errors/warnings.
 	      (err  (ghc-hilit-info-get-err  info))
               (hole (ghc-hilit-info-get-hole info))
               (coln (ghc-hilit-info-get-coln info))
-              (is-same-file
-               (or (file-equal-p ofile file)
-                   (string= (file-truename ofile) (file-truename file)))
-                                        ; In case non-existent
-               )
 	      beg end ovl)
 	  ;; FIXME: This is the Shlemiel painter's algorithm.
 	  ;; If this is a bottleneck for a large code, let's fix.
 	  (goto-char (point-min))
 	  (cond
-	   (is-same-file
+	   ((file-equal-p ofile file)
             (if hole
               (progn
                 (forward-line (1- line))

--- a/elisp/ghc-check.el
+++ b/elisp/ghc-check.el
@@ -165,12 +165,17 @@ nil            do not display errors/warnings.
 	      (err  (ghc-hilit-info-get-err  info))
               (hole (ghc-hilit-info-get-hole info))
               (coln (ghc-hilit-info-get-coln info))
+              (is-same-file
+               (or (file-equal-p ofile file)
+                   (string= (file-truename ofile) (file-truename file)))
+                                        ; In case non-existent
+               )
 	      beg end ovl)
 	  ;; FIXME: This is the Shlemiel painter's algorithm.
 	  ;; If this is a bottleneck for a large code, let's fix.
 	  (goto-char (point-min))
 	  (cond
-	   ((string= (file-truename ofile) (file-truename file))
+	   (is-same-file
             (if hole
               (progn
                 (forward-line (1- line))


### PR DESCRIPTION
In function `ghc-check-highlight-original-buffer` in `ghc-check.el`, filenames are compared by means of `string=`. This is too case-sensitive in case-insensitive filesystems and causes highlight error in some cases, like in #561. I fixed to use `file-equal-p` first, and use `string=` if failed.
