### PR TITLE
Expose GmLogLevel and OutputOpts

### DIFF
--- a/Language/Haskell/GhcMod.hs
+++ b/Language/Haskell/GhcMod.hs
@@ -12,7 +12,9 @@ module Language.Haskell.GhcMod (
   , FileMapping(..)
   , defaultOptions
   -- * Logging
-  , GmLogLevel
+  , GmLogLevel(..)
+  , OutputOpts(..)
+  , LineSeparator(..)
   , increaseLogLevel
   , decreaseLogLevel
   , gmSetLogLevel

--- a/Language/Haskell/GhcMod/Internal.hs
+++ b/Language/Haskell/GhcMod/Internal.hs
@@ -24,7 +24,6 @@ module Language.Haskell.GhcMod.Internal (
   , CompilerMode(..)
   , GhcModLog
   , GmLog(..)
-  , GmLogLevel(..)
   , gmSetLogLevel
   -- * Monad utilities
   , runGhcModT'


### PR DESCRIPTION
These are needed to set options externally
