### PR TITLE
(WIP) Optparse-Applicative for CLI

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -186,6 +186,7 @@ Executable ghc-mod
   Default-Language:     Haskell2010
   Main-Is:              GHCMod.hs
   Other-Modules:        Paths_ghc_mod
+                      , CLI
   GHC-Options:          -Wall -fno-warn-deprecations -threaded
   Default-Extensions:   ConstraintKinds, FlexibleContexts
   HS-Source-Dirs:       src
@@ -196,10 +197,12 @@ Executable ghc-mod
                       , pretty
                       , process
                       , split
+                      , text
                       , mtl >= 2.0
                       , ghc
                       , ghc-mod
                       , fclabels == 2.0.*
+                      , optparse-applicative
 
 Executable ghc-modi
   Default-Language:     Haskell2010

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE OverloadedStrings #-}
+module CLI where
+
+import Data.Text
+import Options.Applicative
+
+type LogLevel = Int
+
+data Component
+  = Module Text
+  | Path FilePath
+
+data Command
+  = Languages
+  | Modules
+  | Flags
+  | Browse
+  | Check
+  | Expand
+  | Debug
+  | DebugComponent
+  | Info
+  | Type
+  | Split
+  | Sig
+  | Refine
+  | Auto
+  | Find
+  | Lint
+  | Root
+  | Doc
+  | DumpSymbols
+  | Boot
+  | LegacyInteractive
+  | Version
+    deriving Show
+
+data Options =
+    Options { verbosity     :: LogLevel
+            , outputLisp    :: Bool
+            , lineSeparator :: Text
+            , linePrefix    :: (Text,Text)
+            , ghcOption     :: [Text]
+            , mapFile       :: (FilePath,FilePath)
+            , withGhc       :: FilePath
+            , withGhcPkg    :: FilePath
+            , withCabal     :: FilePath
+            , withStack     :: FilePath
+            , cmd           :: Command
+            }
+    deriving Show
+
+run :: IO Options
+run =
+  execParser (info optionsParser (fullDesc <> progDesc "ghc-mod" <> header "ghc-mod"))
+
+optionsParser :: Parser Options
+optionsParser =
+  Options <$> (silent <|> verbosity)
+          <*> toLisp
+          <*> lineSep
+          <*> linePrefix
+          <*> ghcOption
+          <*> mapFile
+          <*> withGhc
+          <*> withGhcPkg
+          <*> withCabal
+          <*> withStack
+          <*> commandsParser
+
+    where silent =
+            option auto (long "silent"
+                         <> short 's'
+                         <> help "Be silent, set log level to 0")
+
+          verbosity =
+            option auto (long "verbose"
+                         <> short 'v'
+                         <> help "Increase or set log level. (0-7)"
+                         <> value 3)
+
+          toLisp =
+            switch (long "tolisp"
+                    <> short 'l'
+                    <> help "Format output as an S-Expression")
+
+          lineSep =
+            option auto (long "line-separator"
+                         <> short 'b'
+                         <> help "Output line separator"
+                         <> value "\n")
+
+          linePrefix =
+            (((\[x,y] -> (x,y)) . splitOn ",") <$> (
+                option auto (long "line-prefix"
+                             <> value ","
+                             <> help "Output line separator")))
+
+          ghcOption =
+            option auto (long "ghc-option"
+                         <> value []
+                         <> help "Option to be passed to GHC")
+
+          mapFile =
+            ((\[x,y] -> (show x, show y)) . splitOn ",") <$> (
+              option auto (long "map-file"
+                           <> value ","
+                           <> help "Redirect one file to another, --map-file \"file1.hs=file2.hs\""))
+
+          withGhc =
+            option auto (long "with-ghc"
+                         <> value ""
+                         <> help "GHC executable to use")
+
+          withGhcPkg =
+            option auto (long "with-ghc-pkg"
+                         <> value ""
+                         <> help "ghc-pkg executable to use (only needed when guessing from GHC path fails)")
+
+          withCabal =
+            option auto (long "with-cabal"
+                         <> value ""
+                         <> help "cabal-install executable to use")
+
+          withStack =
+            option auto (long "with-stack"
+                         <> value ""
+                         <> help "stack executable to use")
+
+commandsParser :: Parser Command
+commandsParser =
+  subparser ( command "lang" (
+              info (pure Languages) (desc "Display GHC support"))
+           <> command "list" (
+                 info (pure Modules) (desc "List all modules in this pkg"))
+           <> command "modules" (
+                 info (pure Modules) (desc "List all modules in this pkg"))
+           <> command "flag" (
+                 info (pure Flags) (desc "TODO"))
+           <> command "browse" (
+                 info (pure Browse) (desc "List all exported names for MODULE"))
+           <> command "check" (
+                 info (pure Check) (desc "Type-check a module"))
+           <> command "expand" (
+                 info (pure Expand) (desc "TODO") )
+           <> command "debug" (
+                 info (pure Debug) (desc "Output ghc-mod debug info: paths, etc."))
+           <> command "debug-component" (
+                 info (pure DebugComponent) (desc "Output ghc-mod debug info for a module"))
+           <> command "info" (
+                 info (pure Info) (desc "ghci's :info command"))
+           <> command "type" (
+                 info (pure Type) (desc "ghci's :type command"))
+           <> command "split" (
+                 info (pure Split) (desc "Performs case-split on target"))
+           <> command "sig" (
+                 info (pure Sig) (desc "Generate code stub from type signature"))
+           <> command "refine" (
+                 info (pure Refine) (desc "Attempts to refine target type-holed"))
+           <> command "auto" (
+                 info (pure Auto) (desc "Attempts to solve target typed-hole"))
+           <> command "find" (
+                 info (pure Find) (desc "Lists all modules that define SYMBOL"))
+           <> command "lint" (
+                 info (pure Lint) (desc "Checks files using hlint"))
+           <> command "root" (
+                 info (pure Root) (desc "Outputs project root"))
+           <> command "doc" (
+                 info (pure Doc) (desc "Outputs path of HTML docs for MODULE"))
+           <> command "dumpsym" (
+                 info (pure DumpSymbols) (desc "TODO"))
+           <> command "boot" (
+                 info (pure Boot) (desc "Outputs a lot of stuff"))
+           <> command "legacy-interactive" (
+                 info (pure LegacyInteractive) (desc "Opens a REPL mode, like ghc-modi"))
+           <> command "version" (
+                 info (pure Version) (desc "Outputs ghc-mod version information"))
+           )
+  where desc msg = fullDesc <> progDesc msg

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -89,76 +89,76 @@ parseLogLevel n
 
 optionsParser :: Parser Options
 optionsParser =
-  Options <$> (silent <|> verbosity)
-          <*> toLisp
-          <*> lineSep
-          <*> linePrefix
-          <*> ghcOption
-          <*> mapFile
-          <*> withGhc
-          <*> withGhcPkg
-          <*> withCabal
-          <*> withStack
+  Options <$> (silent' <|> verbosity')
+          <*> toLisp'
+          <*> lineSep'
+          <*> linePrefix'
+          <*> ghcOption'
+          <*> mapFile'
+          <*> withGhc'
+          <*> withGhcPkg'
+          <*> withCabal'
+          <*> withStack'
           <*> commandsParser
 
-    where silent :: Parser LogLevel
-          silent =
+    where
+          silent' =
             (\b -> if b then Silent else Error) <$>
               switch (long "silent"
                       <> short 's'
                       <> help "Be silent, set log level to 0")
 
-          verbosity =
+          verbosity' =
             parseLogLevel <$>
               option auto (long "verbose"
                            <> short 'v'
                            <> help "Increase or set log level. (0-7)"
                            <> value 3)
 
-          toLisp =
+          toLisp' =
             switch (long "tolisp"
                     <> short 'l'
                     <> help "Format output as an S-Expression")
 
-          lineSep =
+          lineSep' =
             option auto (long "line-separator"
                          <> short 'b'
                          <> help "Output line separator"
                          <> value "\n")
 
-          linePrefix =
+          linePrefix' =
             ((\[x,y] -> (x,y)) . splitOn ",") <$>
                 option auto (long "line-prefix"
                              <> value ","
                              <> help "Output line separator")
 
-          ghcOption =
+          ghcOption' =
             option auto (long "ghc-option"
                          <> value []
                          <> help "Option to be passed to GHC")
 
-          mapFile =
+          mapFile' =
             ((\[x,y] -> (show x, show y)) . splitOn ",") <$>
               option auto (long "map-file"
                            <> value ","
                            <> help "Redirect one file to another, --map-file \"file1.hs=file2.hs\"")
 
-          withGhc =
+          withGhc' =
             option auto (long "with-ghc"
                          <> value ""
                          <> help "GHC executable to use")
 
-          withGhcPkg =
+          withGhcPkg' =
             option auto (long "with-ghc-pkg"
                          <> value ""
                          <> help "ghc-pkg executable to use (only needed when guessing from GHC path fails)")
 
-          withCabal =
+          withCabal' =
             option auto (long "with-cabal"
                          <> value ""
                          <> help "cabal-install executable to use")
 
-          withStack =
+          withStack' =
             option auto (long "with-stack"
                          <> value ""
                          <> help "stack executable to use")

--- a/src/GHCMod.hs
+++ b/src/GHCMod.hs
@@ -32,6 +32,7 @@ import Text.PrettyPrint
 import Prelude hiding ((.))
 
 import Misc
+import qualified CLI as C
 
 progVersion :: String -> String
 progVersion pf =
@@ -45,11 +46,11 @@ ghcModiVersion :: String
 ghcModiVersion = progVersion "i"
 
 optionUsage :: (String -> String) -> [OptDescr a] -> [String]
-optionUsage indent opts = concatMap optUsage opts
+optionUsage indent = concatMap optUsage
  where
    optUsage (Option so lo dsc udsc) =
-       [ concat $ intersperse ", " $ addLabel `map` allFlags
-       , indent $ udsc
+       [ intercalate ", " $ addLabel `map` allFlags
+       , indent udsc
        , ""
        ]
     where
@@ -75,7 +76,7 @@ usage =
  \    Global options can be specified before and after the command and\n\
  \    interspersed with command specific options\n\
  \\n"
-   ++ (unlines $ indent <$> optionUsage indent globalArgSpec) ++
+   ++ unlines (indent <$> optionUsage indent globalArgSpec) ++
  "*Commands*\n\
  \    - version\n\
  \        Print the version of the program.\n\
@@ -218,7 +219,7 @@ cmdUsage cmd realUsage =
       isIndented    = ("    " `isPrefixOf`)
       isNotCmdHead  = ( not .  ("    - " `isPrefixOf`))
 
-      containsAnyCmdHead s = (("    - ") `isInfixOf` s)
+      containsAnyCmdHead s = ("    - " `isInfixOf` s)
       containsCurrCmdHead s = (("    - " ++ cmd) `isInfixOf` s)
       isCmdHead s =
           containsAnyCmdHead s &&
@@ -235,7 +236,7 @@ ghcModStyle = style { lineLength = 80, ribbonsPerLine = 1.2 }
 
 ----------------------------------------------------------------
 
-option :: [Char] -> [String] -> String -> ArgDescr a -> OptDescr a
+option :: String -> [String] -> String -> ArgDescr a -> OptDescr a
 option s l udsc dsc = Option s l dsc udsc
 
 reqArg :: String -> (String -> a) -> ArgDescr a
@@ -377,15 +378,15 @@ data InteractiveOptions = InteractiveOptions {
     }
 
 handler :: IOish m => GhcModT m a -> GhcModT m a
-handler = flip gcatches $
+handler = flip gcatches
           [ GHandler $ \(FatalError msg) -> exitError msg
-          , GHandler $ \e@(ExitSuccess) -> throw e
+          , GHandler $ \e@ExitSuccess -> throw e
           , GHandler $ \e@(ExitFailure _) -> throw e
-          , GHandler $ \(InvalidCommandLine e) -> do
+          , GHandler $ \(InvalidCommandLine e) ->
                 case e of
                   Left cmd ->
                       exitError $ "Usage for `"++cmd++"' command:\n\n"
-                                  ++ (cmdUsage cmd usage) ++ "\n"
+                                  ++ cmdUsage cmd usage ++ "\n"
                                   ++ "ghc-mod: Invalid command line form."
                   Right msg -> exitError $ "ghc-mod: " ++ msg
           , GHandler $ \(SomeException e) -> exitError $ "ghc-mod: " ++ show e
@@ -394,6 +395,8 @@ handler = flip gcatches $
 main :: IO ()
 main = do
     hSetEncoding stdout utf8
+    C.run >>= print
+    {-
     args <- getArgs
     case parseGlobalArgs args of
       Left e -> throw e
@@ -401,6 +404,7 @@ main = do
             Handler $ \(e :: GhcModError) ->
               runGmOutT globalOptions $ exitError $ renderStyle ghcModStyle (gmeDoc e)
           ]
+     -}
 
 progMain :: (Options,[String]) -> IO ()
 progMain (globalOptions,cmdArgs) = runGmOutT globalOptions $
@@ -445,7 +449,7 @@ legacyInteractiveLoop symdbreq world = do
     liftIO . setCurrentDirectory =<< cradleRootDir <$> cradle
 
     -- blocking
-    cmdArg <- liftIO $ getLine
+    cmdArg <- liftIO getLine
 
     -- after blocking, we need to see if the world has changed.
 
@@ -455,8 +459,7 @@ legacyInteractiveLoop symdbreq world = do
                 then getCurrentWorld -- TODO: gah, we're hitting the fs twice
                 else return world
 
-    when changed $ do
-        dropSession
+    when changed dropSession
 
     let (cmd':args') = split (keepDelimsR $ condense $ whenElt isSpace) cmdArg
         arg = concat args'
@@ -488,8 +491,8 @@ legacyInteractiveLoop symdbreq world = do
         "unmap-file" ->  unloadMappedFile arg
                      >>  return ""
 
-        "quit"   -> liftIO $ exitSuccess
-        ""       -> liftIO $ exitSuccess
+        "quit"   -> liftIO exitSuccess
+        ""       -> liftIO exitSuccess
         _        -> fatalError $ "unknown command: `" ++ cmd ++ "'"
 
     gmPutStr res >> gmPutStrLn "OK" >> liftIO (hFlush stdout)
@@ -497,7 +500,7 @@ legacyInteractiveLoop symdbreq world = do
  where
    interactiveHandlers =
           [ GHandler $ \e@(FatalError _) -> throw e
-          , GHandler $ \e@(ExitSuccess) -> throw e
+          , GHandler $ \e@ExitSuccess -> throw e
           , GHandler $ \e@(ExitFailure _) -> throw e
           , GHandler $ \(SomeException e) -> gmErrStrLn (show e) >> return ""
           ]
@@ -515,7 +518,7 @@ getFileSourceFromStdin = do
 wrapGhcCommands :: (IOish m, GmOut m) => Options -> [String] -> m ()
 wrapGhcCommands _opts []            = fatalError "No command given (try --help)"
 wrapGhcCommands _opts ("root":_) = gmPutStr =<< rootInfo
-wrapGhcCommands opts args = do
+wrapGhcCommands opts args =
     handleGmError $ runGhcModT opts $ handler $ do
       forM_ (reverse $ optFileMappings opts) $
         uncurry loadMMappedFiles
@@ -633,7 +636,7 @@ sigCmd        = withParseCmd [] $ locAction  "sig"    sig
 autoCmd       = withParseCmd [] $ locAction  "auto"   auto
 refineCmd     = withParseCmd [] $ locAction' "refine" refine
 
-infoCmd       = withParseCmd [] $ action
+infoCmd       = withParseCmd [] action
   where action [file,_,expr] = info file $ Expression expr
         action [file,expr]   = info file $ Expression expr
         action _ = throw $ InvalidCommandLine (Left "info")
@@ -642,9 +645,9 @@ legacyInteractiveCmd = withParseCmd [] go
  where
    go [] =
        legacyInteractive >> return ""
-   go ("help":[]) =
+   go ["help"] =
        return usage
-   go ("version":[]) =
+   go ["version"] =
        return ghcModiVersion
    go _ = throw $ InvalidCommandLine (Left "legacy-interactive")
 

--- a/src/GHCMod.hs
+++ b/src/GHCMod.hs
@@ -25,7 +25,7 @@ import qualified System.Console.GetOpt as O
 import System.FilePath ((</>))
 import System.Directory (setCurrentDirectory, getAppUserDataDirectory,
                         removeDirectoryRecursive)
-import System.Environment (getArgs)
+
 import System.IO
 import System.Exit
 import Text.PrettyPrint

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ packages:
 - '.'
 extra-deps:
 - cabal-helper-0.6.0.0
-resolver: lts-3.1
+resolver: lts-3.5


### PR DESCRIPTION
Would you be interested in this sort of functionality? The goal was to make the command line parsing a bit more robust and to auto-generate all the help dialogues.

This is an early preview that just gets to the point where running it parses command line opts and outputs help dialogues.
## Missing
- Determine arguments that each of the existing commands take
- Fill in more `help` details to achieve parity with existing parser
- Connect parsed command to command runners
- Tests
## Preview
- Execution without commands. I need to tweak METAVARs names to make this nicer, and list out available commands:

```
$ stack exec ghc-mod
Usage: ghc-mod ([-s|--silent] | [-v|--verbose ARG]) [-l|--tolisp]
               [-b|--line-separator ARG] [--line-prefix ARG] [--ghc-option ARG]
               [--map-file ARG] [--with-ghc ARG] [--with-ghc-pkg ARG]
               [--with-cabal ARG] [--with-stack ARG] COMMAND
  ghc-mod
```
- Execution with commands:

```
$ stack exec ghc-mod -- version --help
Usage: ghc-mod version 
  Outputs ghc-mod version information

$ stack exec ghc-mod -- version
Options {verbosity = Error, outputLisp = False, lineSeparator = "\n", linePrefix = ("",""), ghcOption = [], mapFile = ("\"\"","\"\""), withGhc = "", withGhcPkg = "", withCabal = "", withStack = "", cmd = Version}

$ stack exec ghc-mod -- info --help
Usage: ghc-mod info 
  ghci's :info command
```
