### PR TITLE
Fix logging for file mapping in case of temp dir being a subdir of project root

### DIFF
--- a/Language/Haskell/GhcMod/FileMapping.hs
+++ b/Language/Haskell/GhcMod/FileMapping.hs
@@ -37,7 +37,9 @@ loadMappedFile' :: IOish m => FilePath -> FilePath -> Bool -> GhcModT m ()
 loadMappedFile' from to isTemp = do
   cfn <- getCanonicalFileNameSafe from
   unloadMappedFile' cfn
-  addMMappedFile cfn (FileMapping to isTemp)
+  crdl <- cradle
+  let to' = makeRelative (cradleRootDir crdl) to
+  addMMappedFile cfn (FileMapping to' isTemp)
 
 mapFile :: (IOish m, GmState m, GhcMonad m, GmEnv m) =>
             HscEnv -> Target -> m Target

--- a/test/FileMappingSpec.hs
+++ b/test/FileMappingSpec.hs
@@ -163,6 +163,14 @@ spec = do
               mapM_ (uncurry loadMappedFile) fm
               checkSyntax ["File.hs"]
             res `shouldBe` "File.hs:3:1:Warning: Top-level binding with no type signature: main :: IO ()\n"
+        it "works with full path as well" $ do
+          withDirectory_ "test/data/file-mapping/preprocessor" $ do
+            cwd <- getCurrentDirectory
+            let fm = [("File.hs", cwd </> "File_Redir.hs")]
+            res <- run defaultOptions $ do
+              mapM_ (uncurry loadMappedFile) fm
+              checkSyntax ["File.hs"]
+            res `shouldBe` "File.hs:3:1:Warning: Top-level binding with no type signature: main :: IO ()\n"
         it "checks in-memory file" $ do
           withDirectory_ "test/data/file-mapping/preprocessor" $ do
             src <- readFile "File_Redir.hs"


### PR DESCRIPTION
I've found an interesting case when my logging substitution code fails. If a given mapped file is in subdir of a project root, and given with full path, then substitution fails. This happens because span source file, as given by `getSrcFile`, is always relative to project root if it's inside it.

This patch should resolve this.
