### PR TITLE
Update cabal-helper from 0.6.0.0 to 0.6.1.0.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,5 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- cabal-helper-0.6.0.0
+- cabal-helper-0.6.1.0
 resolver: lts-3.1


### PR DESCRIPTION
I found that I had to update this version number to get ghc-mod to build. I'm on Mac using ghc 7.10.2.
