### PR TITLE
Adds report-ghc-errors to turn off *GHC Error* buffer when nil

### DIFF
--- a/elisp/ghc-process.el
+++ b/elisp/ghc-process.el
@@ -27,6 +27,7 @@
 
 (defvar ghc-command "ghc-mod")
 
+(defvar ghc-report-errors t "Report GHC errors to *GHC Error* buffer")
 (defvar ghc-error-buffer "*GHC Error*")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -144,7 +145,8 @@
 		    (with-current-buffer pbuf
 		      (goto-char (point-max))
 		      (insert-buffer-substring tbuf 1 end))
-		  (with-current-buffer (get-buffer-create ghc-error-buffer)
+		  (when ghc-report-errors
+                    (with-current-buffer (get-buffer-create ghc-error-buffer)
 		    (setq buffer-read-only t)
 		    (let* ((buffer-read-only nil)
 			   (inhibit-read-only t)
@@ -156,7 +158,7 @@
 			(goto-char (point-max))
 			(insert-buffer-substring tbuf 1 end)
 			(set-buffer-modified-p nil))
-		      (redisplay))))
+		      (redisplay)))))
 		(delete-region 1 end)))))
 	(goto-char (point-max))
 	(forward-line -1)


### PR DESCRIPTION
hc-mod now writes GHC errors to a new _GHC Error_ buffer only if
report-ghc-errors has the value `t`. If a user wants to silence this
buffer, they should evaluate the following s-expression.

```
(setq ghc-report-errors nil)
```

Fixes kazu-yamamoto/ghc-mod#618
