### PR TITLE
Loggging cradle

### DIFF
--- a/Language/Haskell/GhcMod/Cradle.hs
+++ b/Language/Haskell/GhcMod/Cradle.hs
@@ -100,8 +100,7 @@ stackCradle wdir = do
     -- If dist/setup-config already exists the user probably wants to use cabal
     -- rather than stack, or maybe that's just me ;)
     whenM (liftIO $ doesFileExist $ setupConfigPath "dist") $ do
-                      gmLog GmWarning "" $ (text
-                            "'dist/setup-config' exists, ignoring Stack and using cabal-install instead.") 
+                      gmLog GmWarning "" $ text "'dist/setup-config' exists, ignoring Stack and using cabal-install instead."
                       mzero
 
     senv <- MaybeT $ getStackEnv cabalDir

--- a/Language/Haskell/GhcMod/Cradle.hs
+++ b/Language/Haskell/GhcMod/Cradle.hs
@@ -94,7 +94,7 @@ stackCradle wdir = do
     -- If dist/setup-config already exists the user probably wants to use cabal
     -- rather than stack, or maybe that's just me ;)
     whenM (liftIO $ doesFileExist $ setupConfigPath "dist") $ do
-                      gmLog GmDebug "" $ (text
+                      gmLog GmWarning "" $ (text
                             "'dist/setup-config' exists, ignoring Stack and using cabal-install instead.") 
                       mzero
 

--- a/Language/Haskell/GhcMod/Cradle.hs
+++ b/Language/Haskell/GhcMod/Cradle.hs
@@ -4,6 +4,7 @@ module Language.Haskell.GhcMod.Cradle
   (
     findCradle
   , findCradle'
+  , findCradleNoLog
   , findSpecCradle
   , cleanupCradle
   )
@@ -25,6 +26,8 @@ import Data.Maybe
 import System.Directory
 import System.FilePath
 import Prelude
+import Control.Monad.Trans.Journal (runJournalT)
+
 
 ----------------------------------------------------------------
 
@@ -35,6 +38,9 @@ import Prelude
 findCradle :: (GmLog m, IOish m, GmOut m) => m Cradle
 findCradle = findCradle' =<< liftIO getCurrentDirectory
 
+findCradleNoLog  :: forall m. (IOish m, GmOut m) => m Cradle
+findCradleNoLog = fst <$> (runJournalT findCradle :: m (Cradle, GhcModLog))
+    
 findCradle' :: (GmLog m, IOish m, GmOut m) => FilePath -> m Cradle
 findCradle' dir = run $
     msum [ stackCradle dir

--- a/Language/Haskell/GhcMod/Debug.hs
+++ b/Language/Haskell/GhcMod/Debug.hs
@@ -3,6 +3,7 @@ module Language.Haskell.GhcMod.Debug (debugInfo, rootInfo, componentInfo) where
 import Control.Arrow (first)
 import Control.Applicative
 import Control.Monad
+import Control.Monad.Trans.Journal
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Char
@@ -138,5 +139,5 @@ mapDoc kd ad m = vcat $
 ----------------------------------------------------------------
 
 -- | Obtaining root information.
-rootInfo :: (IOish m, GmOut m) => m String
-rootInfo = (++"\n") . cradleRootDir <$> findCradle
+rootInfo :: forall m. (IOish m, GmOut m) => m String
+rootInfo = (++"\n") . cradleRootDir <$> fst `liftM` (runJournalT findCradle :: m (Cradle, GhcModLog))

--- a/Language/Haskell/GhcMod/Logging.hs
+++ b/Language/Haskell/GhcMod/Logging.hs
@@ -85,14 +85,9 @@ gmLog level loc' doc = do
 
 -- | Appends a collection of logs to the logging environment, with effects
 -- | if their log level specifies it should
-gmLog' :: (MonadIO m, GmLog m, GmOut m) => GhcModLog -> m ()
-gmLog' GhcModLog { gmLogMessages } = do
-  GhcModLog { gmLogLevel = Just level' } <- gmlHistory
-  mapM_ (\(level, _, msgDoc) ->  when (level <= level') $ gmErrStrLn (docToString msgDoc)) gmLogMessages
-  -- instance Monoid GhcModLog takes the second debug level for some reason, so we need to force this to nothing
-  gmlJournal (GhcModLog Nothing (Last Nothing)  gmLogMessages)
-  where
-    docToString msgDoc = dropWhileEnd isSpace $ gmRenderDoc msgDoc
+gmAppendLog ::  (MonadIO m, GmLog m, GmOut m) => GhcModLog -> m ()
+gmAppendLog  GhcModLog { gmLogMessages } = (\(level, loc, msgDoc) -> gmLog level loc msgDoc) `mapM_` gmLogMessages
+    
 
 gmVomit :: (MonadIO m, GmLog m, GmOut m, GmEnv m) => String -> Doc -> String -> m ()
 gmVomit filename doc content = do

--- a/Language/Haskell/GhcMod/Logging.hs
+++ b/Language/Haskell/GhcMod/Logging.hs
@@ -78,6 +78,17 @@ gmLog level loc' doc = do
 
   gmlJournal (GhcModLog Nothing (Last Nothing) [(level, loc', msgDoc)])
 
+-- | Appends a collection of logs to the logging environment, with effects
+-- | if their log level specifies it should
+gmLog' :: (MonadIO m, GmLog m, GmOut m) => GhcModLog -> m ()
+gmLog' newLog@ GhcModLog { gmLogMessages } = do
+  GhcModLog { gmLogLevel = Just level' } <- gmlHistory
+  mapM_ (\(level, _, msgDoc) ->  when (level <= level') $ gmErrStrLn (docToString msgDoc)) gmLogMessages
+  -- instance Monoid GhcModLog takes the second debug level for some reason, so we need to force this to nothing
+  gmlJournal (GhcModLog Nothing (Last Nothing)  gmLogMessages)
+  where
+    docToString msgDoc = dropWhileEnd isSpace $ gmRenderDoc msgDoc
+
 gmVomit :: (MonadIO m, GmLog m, GmOut m, GmEnv m) => String -> Doc -> String -> m ()
 gmVomit filename doc content = do
   gmLog GmVomit "" $ doc <+>: text content

--- a/Language/Haskell/GhcMod/Logging.hs
+++ b/Language/Haskell/GhcMod/Logging.hs
@@ -45,6 +45,11 @@ gmSetLogLevel :: GmLog m => GmLogLevel -> m ()
 gmSetLogLevel level =
     gmlJournal $ GhcModLog (Just level) (Last Nothing) []
 
+gmGetLogLevel :: forall m. GmLog m => m GmLogLevel 
+gmGetLogLevel = do
+  GhcModLog { gmLogLevel = Just level } <-  gmlHistory
+  return level
+               
 gmSetDumpLevel :: GmLog m => Bool -> m ()
 gmSetDumpLevel level =
     gmlJournal $ GhcModLog Nothing (Last (Just level)) []

--- a/Language/Haskell/GhcMod/Logging.hs
+++ b/Language/Haskell/GhcMod/Logging.hs
@@ -86,7 +86,7 @@ gmLog level loc' doc = do
 -- | Appends a collection of logs to the logging environment, with effects
 -- | if their log level specifies it should
 gmLog' :: (MonadIO m, GmLog m, GmOut m) => GhcModLog -> m ()
-gmLog' newLog@ GhcModLog { gmLogMessages } = do
+gmLog' GhcModLog { gmLogMessages } = do
   GhcModLog { gmLogLevel = Just level' } <- gmlHistory
   mapM_ (\(level, _, msgDoc) ->  when (level <= level') $ gmErrStrLn (docToString msgDoc)) gmLogMessages
   -- instance Monoid GhcModLog takes the second debug level for some reason, so we need to force this to nothing

--- a/Language/Haskell/GhcMod/Monad.hs
+++ b/Language/Haskell/GhcMod/Monad.hs
@@ -100,7 +100,7 @@ runGhcModT opt action = liftIO (getCurrentDirectory >>= canonicalizePath) >>= \d
       withGhcModEnv dir' opt $ \(env,lg) ->
         first (fst <$>) <$> runGhcModT' env defaultGhcModState
           (gmSetLogLevel (ooptLogLevel $ optOutput opt) >>
-           gmLog' lg >>
+           gmAppendLog lg >>
            action)
 
 -- | @hoistGhcModT result@. Embed a GhcModT computation's result into a GhcModT

--- a/Language/Haskell/GhcMod/Monad.hs
+++ b/Language/Haskell/GhcMod/Monad.hs
@@ -99,9 +99,9 @@ runGhcModT opt action = liftIO (getCurrentDirectory >>= canonicalizePath) >>= \d
     runGmOutT opt $
       withGhcModEnv dir' opt $ \(env,lg) ->
         first (fst <$>) <$> runGhcModT' env defaultGhcModState
-          ( gmlJournal lg >>
-            gmSetLogLevel (ooptLogLevel $ optOutput opt) >>
-            action)
+          (gmSetLogLevel (ooptLogLevel $ optOutput opt) >>
+           gmLog' lg >>
+           action)
 
 -- | @hoistGhcModT result@. Embed a GhcModT computation's result into a GhcModT
 -- computation. Note that if the computation that returned @result@ modified the

--- a/test/CradleSpec.hs
+++ b/test/CradleSpec.hs
@@ -8,7 +8,6 @@ import System.Directory (canonicalizePath)
 import System.FilePath (pathSeparator)
 import Test.Hspec
 import TestUtils
-import Prelude
 
 import Dir
 
@@ -37,14 +36,14 @@ spec = do
         it "returns the current directory" $ do
             withDirectory_ "/" $ do
                 curDir <- stripLastDot <$> canonicalizePath "/"
-                res <- clean_ $ runGmOutDef findCradle
+                res <- clean_ $ runGmOutDef findCradleNoLog
                 cradleCurrentDir res `shouldBe` curDir
                 cradleRootDir    res `shouldBe` curDir
                 cradleCabalFile  res `shouldBe` Nothing
 
         it "finds a cabal file and a sandbox" $ do
             withDirectory "test/data/cabal-project/subdir1/subdir2" $ \dir -> do
-                res <- relativeCradle dir <$> clean_ (runGmOutDef findCradle)
+                res <- relativeCradle dir <$> clean_ (runGmOutDef findCradleNoLog)
 
                 cradleCurrentDir res `shouldBe`
                     "test/data/cabal-project/subdir1/subdir2"
@@ -56,7 +55,7 @@ spec = do
 
         it "works even if a sandbox config file is broken" $ do
             withDirectory "test/data/broken-sandbox" $ \dir -> do
-                res <- relativeCradle dir <$> clean_ (runGmOutDef findCradle)
+                res <- relativeCradle dir <$> clean_ (runGmOutDef findCradleNoLog)
                 cradleCurrentDir res `shouldBe`
                     "test" </> "data" </> "broken-sandbox"
 


### PR DESCRIPTION
This add log information when detect a "dist" directory.
However, when that happens and stack is in use, it usually errors out before the logs gets printed, upon ghc invocation, 

```
ghc-mod: <command line>: cannot satisfy -package-id cabal-helper-0.6.1.0-b54b7507b116169ed61259452ac741c4:
```

=> we should print the log earlier / catch ?
