### PR TITLE
First attempt at fixing root issue

### DIFF
--- a/Language/Haskell/GhcMod/Debug.hs
+++ b/Language/Haskell/GhcMod/Debug.hs
@@ -140,4 +140,4 @@ mapDoc kd ad m = vcat $
 
 -- | Obtaining root information.
 rootInfo :: forall m. (IOish m, GmOut m) => m String
-rootInfo = (++"\n") . cradleRootDir <$> fst `liftM` (runJournalT findCradle :: m (Cradle, GhcModLog))
+rootInfo = cradleRootDir <$> fst `liftM` (runJournalT findCradle :: m (Cradle, GhcModLog))

--- a/src/GHCMod/Options.hs
+++ b/src/GHCMod/Options.hs
@@ -13,7 +13,7 @@
 --
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, ImplicitParams #-}
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 
 module GHCMod.Options (
@@ -32,19 +32,24 @@ import GHCMod.Options.DocUtils
 import GHCMod.Options.Help
 import GHCMod.Options.ShellParse
 
+import System.Directory (getCurrentDirectory)
+
 parseArgs :: IO (Options, GhcModCommands)
-parseArgs =
+parseArgs = do
+  cwd <- getCurrentDirectory
+  let ?cwd = cwd
   execParser opts
   where
+    opts :: (?cwd :: FilePath) => ParserInfo (Options, GhcModCommands)
     opts = info (argAndCmdSpec <**> helpVersion)
            $$  fullDesc
            <=> header "ghc-mod: Happy Haskell Programming"
 
-parseArgsInteractive :: String -> Either String GhcModCommands
-parseArgsInteractive args =
+parseArgsInteractive :: FilePath -> String -> Either String GhcModCommands
+parseArgsInteractive cwd args =
   handle $ execParserPure (prefs idm) opts $ parseCmdLine args
   where
-    opts = info interactiveCommandsSpec $$ fullDesc
+    opts = let ?cwd = cwd in info interactiveCommandsSpec $$ fullDesc
     handle (Success a) = Right a
     handle (Failure failure) =
           Left $ fst $ renderFailure failure ""
@@ -68,7 +73,7 @@ helpVersion =
         "version" -> readerAbort $ InfoMsg ghcModVersion
         _ -> return id
 
-argAndCmdSpec :: Parser (Options, GhcModCommands)
+argAndCmdSpec :: (?cwd :: FilePath) => Parser (Options, GhcModCommands)
 argAndCmdSpec = (,) <$> globalArgSpec <*> commandsSpec
 
 splitOn :: Eq a => a -> [a] -> ([a], [a])


### PR DESCRIPTION
#### :rotating_light: THIS IS WIP, DO NOT MERGE :rotating_light:

I'd like some comments on the general idea, if possible.

I know it's a bit awkward in places, but I don't see any better options.

General overview:
1. We save initial cwd in GhcMod environment (I used `Options`, as it was readily available, but could probably use cradle as well)
2. We chdir to project root directory as given by `rootInfo` very early in the pipeline (`progMain` in this case)
3. Every time we get a file path from user, we `</>` it with initial cwd. This won't have any effect on absolute paths, but relative paths should work as if ghc-mod was still working from initial cwd.
4. TODO: Logging needs to relativize to initial cwd instead of project root.

This PR is proof-of-concept, but it should give a general idea of what this entails.
