### PR TITLE
Better log-level option

### DIFF
--- a/src/GHCMod/Options/Help.hs
+++ b/src/GHCMod/Options/Help.hs
@@ -23,13 +23,19 @@ import qualified Options.Applicative.Help.Pretty as PP
 import Control.Monad.State
 import GHC.Exts( IsString(..) )
 import Data.Maybe
+import Data.Monoid
+import Prelude
 
 newtype MyDocM s a = MyDoc {unwrapState :: State s a}
   deriving (Monad, Functor, Applicative, MonadState s)
 type MyDoc = MyDocM (Maybe Doc) ()
 
-instance IsString (MyDocM (Maybe Doc) a)  where
+instance IsString (MyDocM (Maybe Doc) a) where
     fromString = append . para
+
+instance Monoid (MyDocM (Maybe Doc) ()) where
+  mappend a b = append $ doc a <> doc b
+  mempty = append PP.empty
 
 para :: String -> Doc
 para = PP.fillSep . map PP.text . words
@@ -65,3 +71,9 @@ progDesc' = progDescDoc . Just . doc
 
 indent :: Int -> MyDoc -> MyDoc
 indent n = append . PP.indent n . doc
+
+int' :: Int -> MyDoc
+int' = append . PP.int
+
+para' :: String -> MyDoc
+para' = append . para


### PR DESCRIPTION
- Allow using strings with `--loglevel`
- `-v` now raises log level relative to `--loglevel` or `--silent`
- Use GmLogLevel instead of Int for parser base

Quote from updated help:

```
  --verbose LEVEL          Set log level (0-7)
                           You can also use strings (case-insensitive):
                           silent, panic, exception, error, warning, info,
                           debug, vomit (default: warning)
```

This relies on that GmLogLevel type constructors are without arguments and follow convention `Gm<uppercase letter><lowercase letters>`

P.S. This is related to discussion in #698 

Note: there are a couple stupid use-cases that are allowed. Some prominent examples:

| option | equivalent | meaning |
| --- | --- | --- |
| `-svvvvvvv` | `-vvv`, `--loglevel vomit` | `GmVomit` |
| `-svvvv` | No option, `--loglevel warning` | `GmWarning` |

That said, `-svv` for `GmException` and similar actually make some sense.
