### PR TITLE
Use new hlint API

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -167,7 +167,7 @@ Library
                       , ghc               < 7.11
                       , ghc-paths         < 0.2
                       , ghc-syb-utils     < 0.3
-                      , hlint             < 1.10 && >= 1.8.61
+                      , hlint             < 1.10 && >= 1.9.26
                       , monad-journal     < 0.8 && >= 0.4
                       , old-time          < 1.2
                       , pretty            < 1.2


### PR DESCRIPTION
Since https://github.com/ndmitchell/hlint/issues/143 is done, we might as well switch to newer API. haskell-src-exts will be bumped to 1.17.\* though, so not sure older ghc versions will handle all that OK.

TL;DR -- I want to see Travis tests.
