### PR TITLE
Use hlint's CppSimple preprocessor

### DIFF
--- a/Language/Haskell/GhcMod/Lint.hs
+++ b/Language/Haskell/GhcMod/Lint.hs
@@ -21,9 +21,10 @@ lint :: IOish m
 lint opt file = ghandle handler $
   withMappedFile file $ \tempfile -> do
     (flags, classify, hint) <- liftIO $ argsSettings $ optLintHlintOpts opt
+    let flags' = flags{cppFlags=CppSimple}
     hSrc <- liftIO $ openFile tempfile ReadMode
     liftIO $ hSetEncoding hSrc (encoding flags)
-    res <- liftIO $ parseModuleEx flags file =<< Just `fmap` hGetContents hSrc
+    res <- liftIO $ parseModuleEx flags' file =<< Just `fmap` hGetContents hSrc
     case res of
       Right m -> pack . map show $ applyHints classify hint [m]
       Left ParseError{parseErrorLocation=loc, parseErrorMessage=err} ->


### PR DESCRIPTION
So, hlint can't handle cabal's preprocessor directives, so I thought that it might be a good idea to convince it to ignore preprocessor directives altogether (might be a good idea anyway, since linting whole source can be beneficial). Hlint3 makes this easy.
