### PR TITLE
use pattern matching + doc

### DIFF
--- a/Language/Haskell/GhcMod/Monad/Types.hs
+++ b/Language/Haskell/GhcMod/Monad/Types.hs
@@ -112,15 +112,19 @@ instance (MonadIO m, MonadBaseControl IO m) => GhcMonad (GmlT m) where
     getSession = gmlGetSession
     setSession = gmlSetSession
 
+-- | Get the underlying GHC session
 gmlGetSession :: (MonadIO m, MonadBaseControl IO m) => GmlT m HscEnv
 gmlGetSession = do
-        ref <- gmgsSession . fromJust . gmGhcSession <$> gmsGet
+        Just s <- gmGhcSession <$> gmsGet
+        let ref = gmgsSession s
         liftIO $ readIORef ref
 
+-- | Set the underlying GHC session
 gmlSetSession :: (MonadIO m, MonadBaseControl IO m) => HscEnv -> GmlT m ()
 gmlSetSession a = do
-        ref <- gmgsSession . fromJust . gmGhcSession <$> gmsGet
-        liftIO $ flip writeIORef a ref
+        Just s <- gmGhcSession <$> gmsGet
+        let ref = gmgsSession s
+        liftIO $ writeIORef ref a
 
 instance GhcMonad LightGhc where
     getSession = (liftIO . readIORef) =<< LightGhc ask

--- a/Language/Haskell/GhcMod/Target.hs
+++ b/Language/Haskell/GhcMod/Target.hs
@@ -104,10 +104,13 @@ dropSession = do
 
     Nothing -> return ()
 
-
+-- | Run a GmlT action (i.e. a function in the GhcMonad) in the context
+-- of certain files or modules
 runGmlT :: IOish m => [Either FilePath ModuleName] -> GmlT m a -> GhcModT m a
 runGmlT fns action = runGmlT' fns return action
 
+-- | Run a GmlT action (i.e. a function in the GhcMonad) in the context
+-- of certain files or modules, with updated GHC flags
 runGmlT' :: IOish m
               => [Either FilePath ModuleName]
               -> (DynFlags -> Ghc DynFlags)
@@ -115,6 +118,9 @@ runGmlT' :: IOish m
               -> GhcModT m a
 runGmlT' fns mdf action = runGmlTWith fns mdf id action
 
+-- | Run a GmlT action (i.e. a function in the GhcMonad) in the context
+-- of certain files or modules, with updated GHC flags and a final
+-- transformation
 runGmlTWith :: IOish m
                  => [Either FilePath ModuleName]
                  -> (DynFlags -> Ghc DynFlags)


### PR DESCRIPTION
I lost some time the other day because I use unGmlT directly instead of runGmlT, which resulted in a fromJust error with no usable stack information. So I added documentation on the useful functions, and used pattern matching as per the Coding Style.
