### PR TITLE
Set file encoding to utf8 in Lint

### DIFF
--- a/Language/Haskell/GhcMod/Lint.hs
+++ b/Language/Haskell/GhcMod/Lint.hs
@@ -22,7 +22,7 @@ lint opt file = ghandle handler $
   withMappedFile file $ \tempfile -> do
     (flags, classify, hint) <- liftIO $ argsSettings $ optLintHlintOpts opt
     hSrc <- liftIO $ openFile tempfile ReadMode
-    liftIO $ hSetEncoding hSrc utf8
+    liftIO $ hSetEncoding hSrc (encoding flags)
     res <- liftIO $ parseModuleEx flags file =<< Just `fmap` hGetContents hSrc
     case res of
       Right m -> pack . map show $ applyHints classify hint [m]


### PR DESCRIPTION
Fixes #722
