### PR TITLE
Add findSymbol’ which doesn’t serialize the result

### DIFF
--- a/Language/Haskell/GhcMod/Find.hs
+++ b/Language/Haskell/GhcMod/Find.hs
@@ -8,6 +8,7 @@ module Language.Haskell.GhcMod.Find
   , lookupSymbol
   , dumpSymbol
   , findSymbol
+  , findSymbol'
   , lookupSym
   , isOutdated
   -- * Load 'SymbolDb' asynchronously
@@ -69,6 +70,11 @@ isOutdated db =
 --   which will be concatenated. 'loadSymbolDb' is called internally.
 findSymbol :: IOish m => Symbol -> GhcModT m String
 findSymbol sym = loadSymbolDb >>= lookupSymbol sym
+
+-- | Lookup `Symbol` in `SymbolDb`. Like `findSymbol` but doesn’t
+-- serialize the result.
+findSymbol' :: IOish m => Symbol -> GhcModT m [ModuleString]
+findSymbol' sym = lookupSym sym <$> loadSymbolDb
 
 -- | Looking up 'SymbolDb' with 'Symbol' to \['ModuleString'\]
 --   which will be concatenated.


### PR DESCRIPTION
We need that in hie since we want to have our own serialization (ofc we could parse the string, but that’s silly).

Also I’m not entirely sure why `loadSymbolDb` is launching a separate executable, but Alan mentioned some racecondition, is that still there? I don’t really like the fact that it means that we need to rely on the `ghc-mod` binary being available at runtime, but if this is necessary then we’ll roll with it.
