### PR TITLE
Issue #727: Don't add .hs-boot modules to context

### DIFF
--- a/Language/Haskell/GhcMod/Gap.hs
+++ b/Language/Haskell/GhcMod/Gap.hs
@@ -228,13 +228,19 @@ withInteractiveContext action = gbracket setup teardown body
         topImports >>= setCtx
         action
     topImports = do
-        ms <- filterM moduleIsInterpreted =<< map ms_mod <$> getModuleGraph
+        ms <- map ms_mod <$> (filterM includeModule =<< getModuleGraph)
         let iis = map (IIModule . modName) ms
 #if __GLASGOW_HASKELL__ >= 704
         return iis
 #else
         return (iis,[])
 #endif
+
+    includeModule m = do
+      let boot = isHsBoot (ms_hsc_src m)
+      interp <- moduleIsInterpreted (ms_mod m)
+      return $ interp && not boot
+
 #if __GLASGOW_HASKELL__ >= 706
     modName = moduleName
     setCtx = setContext


### PR DESCRIPTION
withInteractiveContext was adding the whole module graph to the interactive
context - including .hs-boot modules. This caused each symbol from any .hs-boot
to be loaded twice. The .hs-boot files are of no use to us anyway, so this patch
filters them out.
