### PR TITLE
GHC 8.0 support

### DIFF
--- a/Language/Haskell/GhcMod/Doc.hs
+++ b/Language/Haskell/GhcMod/Doc.hs
@@ -1,20 +1,7 @@
 module Language.Haskell.GhcMod.Doc where
 
 import GHC
-import Language.Haskell.GhcMod.Gap (withStyle, showDocWith)
 import Outputable
-import Pretty (Mode(..))
-
-showPage :: DynFlags -> PprStyle -> SDoc -> String
-showPage dflag style = showDocWith dflag PageMode . withStyle dflag style
-
-showOneLine :: DynFlags -> PprStyle -> SDoc -> String
-showOneLine dflag style = showDocWith dflag OneLineMode . withStyle dflag style
-
--- showForUser :: DynFlags -> PrintUnqualified -> SDoc -> String
--- showForUser dflags unqual sdoc =
---     showDocWith dflags PageMode $
---       runSDoc sdoc $ initSDocContext dflags $ mkUserStyle unqual AllTheWay
 
 getStyle :: GhcMonad m => m PprStyle
 getStyle = do

--- a/Language/Haskell/GhcMod/Gap.hs
+++ b/Language/Haskell/GhcMod/Gap.hs
@@ -155,13 +155,34 @@ setLogAction df f =
     df { log_action = f df }
 #endif
 
+
+#if __GLASGOW_HASKELL__ >= 800
+showPage :: DynFlags -> PprStyle -> SDoc -> String
+showPage dflag style = flip (renderWithStyle dflag) style
+
+showOneLine :: DynFlags -> PprStyle -> SDoc -> String
+showOneLine dflag style = showSDocOneLine . withStyle dflag style
+#else
+
+showPage :: DynFlags -> PprStyle -> SDoc -> String
+showPage dflag style = showDocWith dflag PageMode . withStyle dflag style
+
+showOneLine :: DynFlags -> PprStyle -> SDoc -> String
+showOneLine dflag style = showDocWith dflag OneLineMode . withStyle dflag style
+
 showDocWith :: DynFlags -> Pretty.Mode -> Pretty.Doc -> String
-#if __GLASGOW_HASKELL__ >= 708
+#  if __GLASGOW_HASKELL__ >= 708
+
+showDocWith dflag PageMode . withStyle dflag
+
+
 -- Pretty.showDocWith disappeard.
 -- https://github.com/ghc/ghc/commit/08a3536e4246e323fbcd8040e0b80001950fe9bc
 showDocWith dflags mode = Pretty.showDoc mode (pprCols dflags)
-#else
+#  else
 showDocWith _ = Pretty.showDocWith
+#  endif
+
 #endif
 
 ----------------------------------------------------------------

--- a/NotCPP/Declarations.hs
+++ b/NotCPP/Declarations.hs
@@ -104,18 +104,33 @@ boundNames decl =
 
       TySynD n _ _ -> [(TcClsName, n)]
       ClassD _ n _ _ _ -> [(TcClsName, n)]
-      FamilyD _ n _ _ -> [(TcClsName, n)]
 
+#if __GLASGOW_HASKELL__ >= 800
+      DataD _ n _ _ ctors _ ->
+#else
       DataD _ n _ ctors _ ->
+#endif
           [(TcClsName, n)] ++ map ((,) TcClsName) (conNames `concatMap` ctors)
 
+#if __GLASGOW_HASKELL__ >= 800
+      NewtypeD _ n _ _ ctor _ ->
+#else
       NewtypeD _ n _ ctor _ ->
+#endif
           [(TcClsName, n)] ++ map ((,) TcClsName) (conNames ctor)
 
+#if __GLASGOW_HASKELL__ >= 800
+      DataInstD _ _n _ _ ctors _ ->
+#else
       DataInstD _ _n _ ctors _ ->
+#endif
           map ((,) TcClsName) (conNames `concatMap` ctors)
 
+#if __GLASGOW_HASKELL__ >= 800
+      NewtypeInstD _ _n _ _ ctor _ ->
+#else
       NewtypeInstD _ _n _ ctor _ ->
+#endif
           map ((,) TcClsName) (conNames ctor)
 
       InstanceD _ _ty _ ->
@@ -131,8 +146,17 @@ boundNames decl =
 #endif
 
 #if __GLASGOW_HASKELL__ >= 708
-      ClosedTypeFamilyD n _ _ _ -> [(TcClsName, n)]
       RoleAnnotD _n _ -> error "notcpp: RoleAnnotD not supported yet"
+#endif
+
+#if __GLASGOW_HASKELL__ >= 704 && __GLASGOW_HASKELL__ < 800
+      FamilyD _ n _ _ -> [(TcClsName, n)]
+#elif __GLASGOW_HASKELL__ >= 708 && __GLASGOW_HASKELL__ < 800
+      ClosedTypeFamilyD n _ _ _ -> [(TcClsName, n)]
+#else
+      OpenTypeFamilyD (TypeFamilyHead n _ _ _) -> [(TcClsName, n)]
+      ClosedTypeFamilyD (TypeFamilyHead n _ _ _) _ -> [(TcClsName, n)]
+
 #endif
 
 conNames :: Con -> [Name]

--- a/NotCPP/LookupValueName.hs
+++ b/NotCPP/LookupValueName.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP, TemplateHaskell #-}
 -- | This module uses scope lookup techniques to either export
 -- 'lookupValueName' from @Language.Haskell.TH@, or define
 -- its own 'lookupValueName', which attempts to do the
@@ -25,8 +25,13 @@ bestValueGuess s = do
   case mi of
     Nothing -> no
     Just i -> case i of
+#if __GLASGOW_HASKELL__ >= 800
+      VarI n _ _ -> yes n
+      DataConI n _ _ -> yes n
+#else
       VarI n _ _ _ -> yes n
       DataConI n _ _ _ -> yes n
+#endif
       _ -> err ["unexpected info:", show i]
  where
   no = return Nothing
@@ -34,5 +39,9 @@ bestValueGuess s = do
   err = fail . showString "NotCPP.bestValueGuess: " . unwords
 
 $(recover [d| lookupValueName = bestValueGuess |] $ do
+#if __GLASGOW_HASKELL__ >= 800
+  VarI _ _ _ <- reify (mkName "lookupValueName")
+#else
   VarI _ _ _ _ <- reify (mkName "lookupValueName")
+#endif
   return [])

--- a/NotCPP/Utils.hs
+++ b/NotCPP/Utils.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP, TemplateHaskell #-}
 module NotCPP.Utils where
 
 import Control.Applicative ((<$>))
@@ -24,6 +24,19 @@ recoverMaybe q = recover (return Nothing) (Just <$> q)
 -- | Returns @'Just' ('VarE' n)@ if the info relates to a value called
 -- @n@, or 'Nothing' if it relates to a different sort of thing.
 infoToExp :: Info -> Maybe Exp
-infoToExp (VarI n _ _ _) = Just (VarE n)
-infoToExp (DataConI n _ _ _) = Just (ConE n)
+
+#if __GLASGOW_HASKELL__ >= 800
+infoToExp (VarI n _ _) =
+#else
+infoToExp (VarI n _ _ _) =
+#endif
+    Just (VarE n)
+
+#if __GLASGOW_HASKELL__ >= 800
+infoToExp (DataConI n _ _) =
+#else
+infoToExp (DataConI n _ _ _) =
+#endif
+    Just (ConE n)
+
 infoToExp _ = Nothing

--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -158,24 +158,24 @@ Library
                         System.Directory.ModTime
   Build-Depends:        base              < 5 && >= 4.0
                       , bytestring        < 0.11
-                      , binary            < 0.8 && >= 0.5.1.0
+                      , binary            < 0.9 && >= 0.5.1.0
                       , containers        < 0.6
                       , cabal-helper      < 0.7 && >= 0.6.3.0
                       , deepseq           < 1.5
                       , directory         < 1.3
                       , filepath          < 1.5
-                      , ghc               < 7.11
+                      , ghc               < 8.2
                       , ghc-paths         < 0.2
                       , ghc-syb-utils     < 0.3
                       , hlint             < 1.10 && >= 1.9.26
                       , monad-journal     < 0.8 && >= 0.4
                       , old-time          < 1.2
                       , pretty            < 1.2
-                      , process           < 1.3
+                      , process           < 1.5
                       , syb               < 0.7
                       , temporary         < 1.3
-                      , time              < 1.6
-                      , transformers      < 0.5
+                      , time              < 1.7
+                      , transformers      < 0.6
                       , transformers-base < 0.5
                       , mtl               < 2.3 && >= 2.0
                       , monad-control     < 1.1 && >= 1
@@ -211,10 +211,10 @@ Executable ghc-mod
                       , directory < 1.3
                       , filepath  < 1.5
                       , pretty    < 1.2
-                      , process   < 1.3
+                      , process   < 1.5
                       , split     < 0.3
                       , mtl       < 2.3 && >= 2.0
-                      , ghc       < 7.11
+                      , ghc       < 8.1
                       , monad-control ==1.0.*
                       , fclabels  ==2.0.*
                       , optparse-applicative >=0.11.0 && <0.13.0
@@ -231,13 +231,13 @@ Executable ghc-modi
   Default-Extensions:   ConstraintKinds, FlexibleContexts
   HS-Source-Dirs:       src, .
   Build-Depends:        base      < 5 && >= 4.0
-                      , binary    < 0.8 && >= 0.5.1.0
+                      , binary    < 0.9 && >= 0.5.1.0
                       , deepseq   < 1.5
                       , directory < 1.3
                       , filepath  < 1.5
-                      , process   < 1.3
+                      , process   < 1.5
                       , old-time  < 1.2
-                      , time      < 1.6
+                      , time      < 1.7
                       , ghc-mod
 
 Test-Suite doctest

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,5 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- cabal-helper-0.6.2.0
+- cabal-helper-0.6.3.1
 resolver: lts-3.20


### PR DESCRIPTION
Still very much WIP. Needs `--allow-newer` on cabal commands as well as git versions of either and fclabels (from https://github.com/sebastiaanvisser/fclabels/pull/30).

Working on fixing errors in Gap but getting this stuff to compile across 5 different GHC versions is becoming a bit of a pain. Maybe we'll drop a few this time around.
