### PR TITLE
Fix output encoding in loadMappedFileSource

### DIFF
--- a/Language/Haskell/GhcMod/FileMapping.hs
+++ b/Language/Haskell/GhcMod/FileMapping.hs
@@ -46,8 +46,10 @@ loadMappedFileSource :: IOish m
                      -> GhcModT m ()
 loadMappedFileSource from src = do
   tmpdir <- cradleTempDir `fmap` cradle
+  enc <- liftIO . mkTextEncoding . optEncoding =<< options
   to <- liftIO $ do
     (fn, h) <- openTempFile tmpdir (takeFileName from)
+    hSetEncoding h enc
     hPutStr h src
     hClose h
     return fn


### PR DESCRIPTION
Nothing to see here, just another place to fix IO encoding in.
