### PR TITLE
Fix 710 case split crash

### DIFF
--- a/Language/Haskell/GhcMod/CaseSplit.hs
+++ b/Language/Haskell/GhcMod/CaseSplit.hs
@@ -29,6 +29,7 @@ import Language.Haskell.GhcMod.Logging
 import Language.Haskell.GhcMod.Types
 import Language.Haskell.GhcMod.Utils (withMappedFile)
 import Language.Haskell.GhcMod.FileMapping (fileModSummaryWithMapping)
+import Control.DeepSeq
 
 ----------------------------------------------------------------
 -- CASE SPLITTING
@@ -55,19 +56,17 @@ splits file lineNo colNo =
       style <- getStyle
       dflag <- G.getSessionDynFlags
       modSum <- fileModSummaryWithMapping (cradleCurrentDir crdl </> file)
-      whenFound' oopts (getSrcSpanTypeForSplit modSum lineNo colNo) $ \x -> case x of
-        (SplitInfo varName bndLoc (varLoc,varT) _matches) -> do
-          let varName' = showName dflag style varName  -- Convert name to string
+      whenFound' oopts (getSrcSpanTypeForSplit modSum lineNo colNo) $ \x -> do
+          let (varName, bndLoc, (varLoc,varT))
+                | (SplitInfo vn bl vlvt _matches) <- x
+                = (vn, bl, vlvt)
+                | (TySplitInfo vn bl vlvt) <- x
+                = (vn, bl, vlvt)
+              varName' = showName dflag style varName  -- Convert name to string
           t <- withMappedFile file $ \file' ->
                 genCaseSplitTextFile file' (SplitToTextInfo varName' bndLoc varLoc $
                                              getTyCons dflag style varName varT)
-          return (fourInts bndLoc, t)
-        (TySplitInfo varName bndLoc (varLoc,varT)) -> do
-          let varName' = showName dflag style varName  -- Convert name to string
-          t <- withMappedFile file $ \file' ->
-                genCaseSplitTextFile file' (SplitToTextInfo varName' bndLoc varLoc $
-                                             getTyCons dflag style varName varT)
-          return (fourInts bndLoc, t)
+          return $!! (fourInts bndLoc, t)
  where
    handler (SomeException ex) = do
      gmLog GmException "splits" $
@@ -207,8 +206,8 @@ genCaseSplitTextFile file info = liftIO $ do
   return $ getCaseSplitText (T.lines t) info
 
 getCaseSplitText :: [T.Text] -> SplitToTextInfo -> String
-getCaseSplitText t (SplitToTextInfo { sVarName = sVN, sBindingSpan = sBS
-                                       , sVarSpan = sVS, sTycons = sT })  =
+getCaseSplitText t SplitToTextInfo{ sVarName = sVN, sBindingSpan = sBS
+                                       , sVarSpan = sVS, sTycons = sT }  =
   let bindingText = getBindingText t sBS
       difference  = srcSpanDifference sBS sVS
       replaced    = map (replaceVarWithTyCon bindingText difference sVN) sT

--- a/test/CaseSplitSpec.hs
+++ b/test/CaseSplitSpec.hs
@@ -39,3 +39,8 @@ spec = do
                 res `shouldBe` "38 21 38 59"++
                         " \"mlReverse' Nil accum = _mlReverse_body\NUL"++
                         "                    mlReverse' (Cons xs'1 xs'2) accum = _mlReverse_body\"\n"
+
+        it "doesn't crash when source doesn't make sense" $
+            withDirectory_ "test/data/case-split" $ do
+                res <- runD $ splits "Crash.hs" 4 6
+                res `shouldBe` []

--- a/test/data/case-split/Crash.hs
+++ b/test/data/case-split/Crash.hs
@@ -1,0 +1,4 @@
+module Crash where
+
+test :: Maybe a
+test x = undefined


### PR DESCRIPTION
Admittedly, this is a stupid fix. Aside from a bit of duplication reduction, all this patch does is forces result value for case split. Since this happens in `ghandle` block, this effectively works to suppress the error.
