### PR TITLE
Add setup-depends for cabal 1.24

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -95,6 +95,15 @@ Extra-Source-Files:     ChangeLog
                         test/data/stack-project/src/*.hs
                         test/data/stack-project/test/*.hs
 
+Custom-Setup
+  Setup-Depends:         base
+                       , Cabal
+                       , containers
+                       , filepath
+                       , process
+                       , template-haskell
+                       , transformers
+
 Library
   Default-Language:     Haskell2010
   GHC-Options:          -Wall -fno-warn-deprecations


### PR DESCRIPTION
This stanca is ignored by older cabal versions and it is necessary for 1.24.
