### PR TITLE
Fix the slow checking issue in interactive mode (remove resetTargets)

### DIFF
--- a/Language/Haskell/GhcMod/Target.hs
+++ b/Language/Haskell/GhcMod/Target.hs
@@ -462,7 +462,6 @@ loadTargets opts targetStrs = do
     let interp = needsHscInterpreted mg
     target <- hscTarget <$> getSessionDynFlags
     when (interp && target /= HscInterpreted) $ do
-      resetTargets targets
       _ <- setSessionDynFlags . setHscInterpreted =<< getSessionDynFlags
       gmLog GmInfo "loadTargets" $ text "Target needs interpeter, switching to LinkInMemory/HscInterpreted. Perfectly normal if anything is using TemplateHaskell, QuasiQuotes or PatternSynonyms."
 
@@ -487,11 +486,6 @@ loadTargets opts targetStrs = do
           relativeFilePath = makeRelative (cradleRootDir crdl) filePath
       return $ Target tid taoc src
     relativize tgt = return tgt
-
-    resetTargets targets' = do
-        setTargets []
-        void $ load LoadAllTargets
-        setTargets targets'
 
     showTargetId (Target (TargetModule s) _ _) = moduleNameString s
     showTargetId (Target (TargetFile s _) _ _) = s


### PR DESCRIPTION
This is a fix for #779.

We found that `resetTargets` in `loadTargets` causes ghc-mod(i) to reload everything and thus slows down the typecheck significantly. We're not sure why `loadTargets` needed to call `resetTargets` in the first place but so far it seems to be fine without the call.
