### PR TITLE
Make tests work under `stack test`

### DIFF
--- a/Language/Haskell/GhcMod/Utils.hs
+++ b/Language/Haskell/GhcMod/Utils.hs
@@ -40,7 +40,7 @@ import System.IO.Temp (createTempDirectory)
 import System.Process (readProcess)
 import Text.Printf
 
-import Paths_ghc_mod (getLibexecDir)
+import Paths_ghc_mod (getLibexecDir, getBinDir)
 import Utils
 import Prelude
 
@@ -84,7 +84,11 @@ ghcModExecutable = do
     dir <- takeDirectory <$> getExecutablePath'
     return $ (if dir == "." then "" else dir) </> "ghc-mod"
 #else
-ghcModExecutable = fmap (</> "dist/build/ghc-mod/ghc-mod") getCurrentDirectory
+ghcModExecutable = do
+  gpp <- lookupEnv "STACK_EXE"
+  case gpp of
+    Just _ -> fmap (</> "ghc-mod") getBinDir
+    _      -> fmap (</> "dist/build/ghc-mod/ghc-mod") getCurrentDirectory
 #endif
 
 getExecutablePath' :: IO FilePath

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,7 +13,9 @@ import TestUtils
 
 main :: IO ()
 main = do
+#if __GLASGOW_HASKELL__ >= 708
   unsetEnv "GHC_PACKAGE_PATH"
+#endif
   let sandboxes = [ "test/data/cabal-project"
                   , "test/data/check-packageid"
                   , "test/data/duplicate-pkgver/"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,11 +7,13 @@ import Control.Monad (void)
 import Data.List
 import Language.Haskell.GhcMod (debugInfo)
 import System.Process
+import System.Environment
 import Test.Hspec
 import TestUtils
 
 main :: IO ()
 main = do
+  unsetEnv "GHC_PACKAGE_PATH"
   let sandboxes = [ "test/data/cabal-project"
                   , "test/data/check-packageid"
                   , "test/data/duplicate-pkgver/"


### PR DESCRIPTION
~~Essentially wraps all `cabal configure` calls with a bracket that unsets
GHC_PACKAGE_PATH and passes paths from there as arguments instead.~~

~~Also fixes `ghcModExecutable` for spec to use cabal's getBinDir (which we should've done a while ago, but oh well)~~

~~NB: pay close attention to `CabalHelper`, this may have some unforeseen side effects if user has `GHC_PACKAGE_PATH` set. That said, ghc-mod just miserably failed in this case before, so it's arguably irrelevant. Might want to limit bracketing to spec environment though to preserve old behavior.~~

1) Unset `GHC_PACKAGE_PATH` in `test/Main.hs`
2) Determine `ghcModExecutable` based on `STACK_EXE` in spec.
