### PR TITLE
Stack travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   # - git clone --depth=1 https://github.com/DanielG/cabal-helper.git
   - stack --no-terminal setup --resolver=ghc-$GHCVER
   - stack --no-terminal install cabal-install --resolver=$RES
-  - cabal update
+  - travis_retry cabal update
   - stack --no-terminal install happy --resolver=$RES
   # - stack init --ignore-subdirs --resolver=ghc-$GHCVER ./ cabal-helper/
   # - stack init --ignore-subdirs --resolver=ghc-$GHCVER ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 script:
   - cabal check
   - |
-    case "$TRAVIS_BRANCH" of
+    case "$TRAVIS_BRANCH" in
     "release"*)
       touch ChangeLog
       sdistdir="$TRAVIS_BUILD_DIR/../sdist-test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
   directories:
   - $HOME/.stack
   - $HOME/.ghc-mod
-  - $TRAVIS_BUILD_DIR/.stack-work/install
 
 addons:
   apt:
@@ -22,13 +21,24 @@ before_install:
   - stack --version
 
 install:
-  #- git clone --depth=1 https://github.com/DanielG/cabal-helper.git
+  # - git clone --depth=1 https://github.com/DanielG/cabal-helper.git
   - stack setup --resolver=ghc-$GHCVER
   - stack install cabal-install --resolver=$RES
   - cabal update
   - stack install happy --resolver=$RES
-  #- stack init --ignore-subdirs --resolver=ghc-$GHCVER ./ cabal-helper/
-  - stack init --ignore-subdirs --resolver=ghc-$GHCVER ./
+  # - stack init --ignore-subdirs --resolver=ghc-$GHCVER ./ cabal-helper/
+  # - stack init --ignore-subdirs --resolver=ghc-$GHCVER ./
+  - |
+    resf="ghc-$GHCVER.yaml"
+    echo "resolver: ghc-$GHCVER" > "$resf"
+    stack solver --update-config --stack-yaml="$resf"
+    sed -i 's/^resolver:/compiler:/;s/^extra-deps:/packages:/' "$resf"
+    echo "resolver: { name: 'ghc-$GHCVER', location: './$resf' }" > stack.yaml
+    ir=$( stack path --snapshot-install-root )
+    ls -d ${ir%/custom-ghc-*}/custom-ghc-* | grep -v "${ir%/*}" | while read i; do
+      rm -rfv "$i"
+    done
+
 
 script:
   - cabal check

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,16 @@ script:
   - cabal check
   - stack --no-terminal build --test --no-run-tests
   - stack --no-terminal test ghc-mod:spec
+  - |
+    if [ -r "$TRAVIS_BUILD_DIR/ChangeLog" ]; then
+      sdistdir="$TRAVIS_BUILD_DIR/../sdist-test"
+      mkdir -p "$sdistdir"
+      tar zvxf $(stack sdist 2>&1 | tail -n1 | sed 's/.* //') --strip-components=1 -C "$sdistdir"
+      cp "ghc-$GHCVER.yaml" stack.yaml "$sdistdir"
+      cd "$sdistdir"
+      stack --no-terminal build --test --no-run-tests
+      stack --no-terminal test ghc-mod:spec
+    fi
 
 matrix:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ install:
   - stack --no-terminal install cabal-install --resolver=$RES
   - travis_retry cabal update
   - stack --no-terminal install happy --resolver=$RES
-  # - stack init --ignore-subdirs --resolver=ghc-$GHCVER ./ cabal-helper/
-  # - stack init --ignore-subdirs --resolver=ghc-$GHCVER ./
   - |
     resf="ghc-$GHCVER.yaml"
     echo "resolver: ghc-$GHCVER" > "$resf"
+    echo "packages: ['.']" >> "$resf"
     stack --no-terminal solver --update-config --stack-yaml="$resf"
     sed -i 's/^resolver:/compiler:/;s/^extra-deps:/packages:/' "$resf"
     echo "resolver: { name: 'ghc-$GHCVER', location: './$resf' }" > stack.yaml
+    echo "packages: ['.']" >> stack.yaml
     ir=$( stack path --snapshot-install-root )
     ls -d ${ir%/custom-ghc-*}/custom-ghc-* | grep -v "${ir%/*}" | while read i; do
       rm -rfv "$i"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,16 +43,16 @@ install:
 script:
   - cabal check
   - |
-  case "$TRAVIS_BRANCH" of
-  "release"*)
-    touch ChangeLog
-    sdistdir="$TRAVIS_BUILD_DIR/../sdist-test"
-    mkdir -p "$sdistdir"
-    tar zvxf $(stack sdist 2>&1 | tail -n1 | sed 's/.* //') --strip-components=1 -C "$sdistdir"
-    cp "ghc-$GHCVER.yaml" stack.yaml "$sdistdir"
-    cd "$sdistdir"
-    ;;
-  esac
+    case "$TRAVIS_BRANCH" of
+    "release"*)
+      touch ChangeLog
+      sdistdir="$TRAVIS_BUILD_DIR/../sdist-test"
+      mkdir -p "$sdistdir"
+      tar zvxf $(stack sdist 2>&1 | tail -n1 | sed 's/.* //') --strip-components=1 -C "$sdistdir"
+      cp "ghc-$GHCVER.yaml" stack.yaml "$sdistdir"
+      cd "$sdistdir"
+      ;;
+    esac
   - stack --no-terminal build --test --no-run-tests
   - stack --no-terminal test ghc-mod:spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,18 +42,19 @@ install:
 
 script:
   - cabal check
+  - |
+  case "$TRAVIS_BRANCH" of
+  "release"*)
+    touch ChangeLog
+    sdistdir="$TRAVIS_BUILD_DIR/../sdist-test"
+    mkdir -p "$sdistdir"
+    tar zvxf $(stack sdist 2>&1 | tail -n1 | sed 's/.* //') --strip-components=1 -C "$sdistdir"
+    cp "ghc-$GHCVER.yaml" stack.yaml "$sdistdir"
+    cd "$sdistdir"
+    ;;
+  esac
   - stack --no-terminal build --test --no-run-tests
   - stack --no-terminal test ghc-mod:spec
-  - |
-    if [ -r "$TRAVIS_BUILD_DIR/ChangeLog" ]; then
-      sdistdir="$TRAVIS_BUILD_DIR/../sdist-test"
-      mkdir -p "$sdistdir"
-      tar zvxf $(stack sdist 2>&1 | tail -n1 | sed 's/.* //') --strip-components=1 -C "$sdistdir"
-      cp "ghc-$GHCVER.yaml" stack.yaml "$sdistdir"
-      cd "$sdistdir"
-      stack --no-terminal build --test --no-run-tests
-      stack --no-terminal test ghc-mod:spec
-    fi
 
 matrix:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,46 @@
-language: haskell
-ghc:
-  - 7.6
-  - 7.8
-
+language: c
 sudo: false
-
-addons:
-  apt:
-    packages:
-    - zlib1g-dev
 
 cache:
   apt: true
   directories:
-  - ~/.cabal
-  - ~/.ghc
-  - ~/.stack
+  - $HOME/.stack
+  - $HOME/.ghc-mod
+  - $TRAVIS_BUILD_DIR/.stack-work/install
 
-before_cache:
-  - rm -f $HOME/.cabal/logs $HOME/.cabal/packages/*/build-reports.log
+addons:
+  apt:
+    packages:
+      - libfcgi-dev
+      - libgmp-dev
 
 before_install:
-  - wget https://github.com/commercialhaskell/stack/releases/download/v0.1.3.1/stack-0.1.3.1-x86_64-linux.gz
-  - mkdir stack-bin
-  - gunzip stack-0.1.3.1-x86_64-linux.gz
-  - mv stack-0.1.3.1-x86_64-linux stack-bin/stack
-  - chmod +x stack-bin/stack
-  - export PATH=$(pwd)/stack-bin:$PATH
+  - unset CC
+  - mkdir -p ~/.local/bin
+  - export PATH=$HOME/.local/bin:$PATH
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   - stack --version
 
 install:
-  - export CABAL_VER="$(ghc-pkg describe ghc | sed -n '/^depends:/,/^[a-z]/p' | head -n-1 | sed '1{s/^depends://}' | grep " *Cabal" | tr -d "[:space:]" | sed 's/^Cabal-\([0-9.]*\)-.*/\1/g')"
-  - echo $CABAL_VER
+  #- git clone --depth=1 https://github.com/DanielG/cabal-helper.git
+  - stack setup --resolver=ghc-$GHCVER
+  - stack install cabal-install --resolver=$RES
   - cabal update
-  - cabal install happy
-  - happy --version
-  - git clone --depth=1 https://github.com/DanielG/cabal-helper.git
-  - cabal install cabal-helper/ --constraint "Cabal == ${CABAL_VER}"
-  - cabal install -j --only-dependencies --enable-tests
-
+  - stack install happy --resolver=$RES
+  #- stack init --ignore-subdirs --resolver=ghc-$GHCVER ./ cabal-helper/
+  - stack init --ignore-subdirs --resolver=ghc-$GHCVER ./
 
 script:
-  - touch ChangeLog # Create ChangeLog if we're not on the release branch
   - cabal check
-  - cabal sdist
-  - export SRC_TGZ="$PWD/dist/$(cabal info . | awk '{print $2 ".tar.gz";exit}')"
-  - rm -rf /tmp/test && mkdir -p /tmp/test
-  - cd /tmp/test
-  - tar -xf $SRC_TGZ && cd ghc-mod*/
-#  - if [ -n "$(ghc --version | awk '{ print $8 }' | sed -n '/^7.8/p')" ]; then export WERROR="--ghc-option=-Werror"; fi
-  - cabal configure --enable-tests
-  - cabal build
-  - export ghc_mod_datadir=$PWD
-  - cabal test
+  - stack build
+  - stack test ghc-mod:spec
 
 matrix:
-  allow_failures:
-    - env: GHCVER=head
+  matrix:
+  include:
+  - env: GHCVER=7.8.4 RES=lts-2.22
+    compiler: ': #GHC 7.8.4'
+  - env: GHCVER=7.10.3 RES=lts-6.9
+    compiler: ': #GHC 7.10.3'
+  - env: GHCVER=8.0.1 RES=nightly-2016-08-01
+    compiler: ': #GHC 8.0.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,16 @@ before_install:
 
 install:
   # - git clone --depth=1 https://github.com/DanielG/cabal-helper.git
-  - stack setup --resolver=ghc-$GHCVER
-  - stack install cabal-install --resolver=$RES
+  - stack --no-terminal setup --resolver=ghc-$GHCVER
+  - stack --no-terminal install cabal-install --resolver=$RES
   - cabal update
-  - stack install happy --resolver=$RES
+  - stack --no-terminal install happy --resolver=$RES
   # - stack init --ignore-subdirs --resolver=ghc-$GHCVER ./ cabal-helper/
   # - stack init --ignore-subdirs --resolver=ghc-$GHCVER ./
   - |
     resf="ghc-$GHCVER.yaml"
     echo "resolver: ghc-$GHCVER" > "$resf"
-    stack solver --update-config --stack-yaml="$resf"
+    stack --no-terminal solver --update-config --stack-yaml="$resf"
     sed -i 's/^resolver:/compiler:/;s/^extra-deps:/packages:/' "$resf"
     echo "resolver: { name: 'ghc-$GHCVER', location: './$resf' }" > stack.yaml
     ir=$( stack path --snapshot-install-root )
@@ -42,8 +42,8 @@ install:
 
 script:
   - cabal check
-  - stack build
-  - stack test ghc-mod:spec
+  - stack --no-terminal build --test --no-run-tests
+  - stack --no-terminal test ghc-mod:spec
 
 matrix:
   matrix:


### PR DESCRIPTION
This builds on #818. ~~Ignore for now, exists for testing purposes.~~

So this works for ghc≥7.8.

Pros:
- Intelligently caches dependencies
- No interleaving problems in test output
- Uses stack-supplied GHC, hence works for ghc-7.10 and ghc-8
- Hopefully doesn't mess with us, but that's yet to be seen

Cons:
- GHC-7.6 is out of luck
- Doesn't directly test cabal build (although that should, in general, work, see below)
- Doctest doesn't work

Caveats:
- If hackage dependencies change, it will rebuild _everything_
- Uses some hacking wrt stack's `stack.yaml`/custom resolver syntax. If any of that ever changes, everything will break horribly.
- sdist test is only run on `release*` branches. Otherwise, a direct tree build is performed.
### On dependency caching

So, this travisfile uses stack's 'ghc-*' resolvers and cabal's dependency solver to pull dependencies from hackage directly. Only exceptions are happy and cabal-install itself, which are pulled from stackage.

It creates a custom stack resolver with all packages cabal thinks are needed for build and then caches its snapshot. Since custom resolver paths are hashed, it's pretty much impossible to update a single dependency in-place, so all dependencies will have to be rebuilt. I don't see this as much of a detriment, since updating dependencies in-place is asking for trouble anyway, and with nightly builds dependencies will hopefully be updated 'in background'.

Since it uses cabal's dependency solver, build should be pretty much equivalent to what one would get with `cabal build`.
