### PR TITLE
Don't build stack dependencies by default

### DIFF
--- a/Language/Haskell/GhcMod/Options/Options.hs
+++ b/Language/Haskell/GhcMod/Options/Options.hs
@@ -146,6 +146,10 @@ globalArgSpec = Options
           <=> value "UTF-8"
           <=> showDefault
           <=> help "I/O encoding"
+      <*> switch
+          $$  long "stack-build-deps"
+          <=> showDefault
+          <=> help "Build dependencies if needed when using stack"
   where
     fileMappingSpec =
       getFileMapping . splitOn '=' <$> strOption

--- a/Language/Haskell/GhcMod/Types.hs
+++ b/Language/Haskell/GhcMod/Types.hs
@@ -106,6 +106,7 @@ data Options = Options {
   , optGhcUserOptions :: [GHCOption]
   , optFileMappings   :: [(FilePath, Maybe FilePath)]
   , optEncoding       :: String
+  , optStackBuildDeps :: Bool
   } deriving (Show)
 
 -- | A default 'Options'.
@@ -126,6 +127,7 @@ defaultOptions = Options {
   , optGhcUserOptions = []
   , optFileMappings   = []
   , optEncoding       = "UTF-8"
+  , optStackBuildDeps = False
   }
 
 ----------------------------------------------------------------


### PR DESCRIPTION
Adds a global option `--stack-build-deps` to enable old behavior
