### PR TITLE
Use HLint3.hlint in Lint

### DIFF
--- a/Language/Haskell/GhcMod/Lint.hs
+++ b/Language/Haskell/GhcMod/Lint.hs
@@ -9,8 +9,7 @@ import Language.Haskell.GhcMod.Monad
 import Language.Haskell.HLint3
 
 import Language.Haskell.GhcMod.Utils (withMappedFile)
-import Language.Haskell.Exts.SrcLoc (SrcLoc(..))
-import System.IO
+import Language.Haskell.Exts.SrcLoc (SrcSpan(..))
 
 -- | Checking syntax of a target file using hlint.
 --   Warnings and errors are returned.
@@ -20,15 +19,12 @@ lint :: IOish m
      -> GhcModT m String
 lint opt file = ghandle handler $
   withMappedFile file $ \tempfile -> do
-    (flags, classify, hint) <- liftIO $ argsSettings $ optLintHlintOpts opt
-    hSrc <- liftIO $ openFile tempfile ReadMode
-    liftIO $ hSetEncoding hSrc (encoding flags)
-    res <- liftIO $ parseModuleEx flags file =<< Just `fmap` hGetContents hSrc
-    case res of
-      Right m -> pack . map show $ filter ((/=Ignore) . ideaSeverity) $ applyHints classify hint [m]
-      Left ParseError{parseErrorLocation=loc, parseErrorMessage=err} ->
-        return $ showSrcLoc loc ++ ":Error:" ++ err ++ "\n"
+    res <- liftIO $ hlint $ "--quiet" : tempfile : optLintHlintOpts opt
+    pack . map (show . substFile file tempfile) $ res
   where
     pack = convert' . map init -- init drops the last \n.
     handler (SomeException e) = return $ checkErrorPrefix ++ show e ++ "\n"
-    showSrcLoc (SrcLoc f l c) = concat [f, ":", show l, ":", show c]
+    substFile orig temp idea
+      | srcSpanFilename (ideaSpan idea) == temp
+      = idea{ideaSpan=(ideaSpan idea){srcSpanFilename = orig}}
+    substFile _ _ idea = idea


### PR DESCRIPTION
Related: #826 

So, this seems to work fine, although passing `--quiet` seems a bit more brittle than it should be.

@DanielG, up to you if we want to use this or wait until hlint upstream fixes (I will report an issue soon)
