### PR TITLE
Basic idea for outputting proper datatypes (mock interface)

### DIFF
--- a/Language/Haskell/GhcMod/Outputable.hs
+++ b/Language/Haskell/GhcMod/Outputable.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
+module Language.Haskell.GhcMod.Outputable where
+
+import Language.Haskell.GhcMod.Types
+
+data NoOutputConfig = NoOutputConfig
+
+data OutputFormat = PlainFormat
+
+class Outputable config a where
+  showOutput :: IOish m => OutputFormat -> config -> a -> m String
+
+instance Outputable NoOutputConfig String where
+  showOutput PlainFormat _ = return

--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -153,6 +153,7 @@ Library
                         Language.Haskell.GhcMod.Monad.State
                         Language.Haskell.GhcMod.Monad.Types
                         Language.Haskell.GhcMod.Output
+                        Language.Haskell.GhcMod.Outputable
                         Language.Haskell.GhcMod.PathsAndFiles
                         Language.Haskell.GhcMod.PkgDoc
                         Language.Haskell.GhcMod.Pretty


### PR DESCRIPTION
Here's a pretty barebones implementation of what I had in mind in #823, more or less.

Admittedly, didn't think too much about structure, but long story short I wanted to have at least a theoretical ability to have multiple output formats, hence `OutputFormat` datatype.

`*OutputConfig` should allow us to move things like `--detail` from actual library implementation to output format implementation (since, you know, library functions shouldn't have to format output, I would assume in most cases we'd like to dump all information we can to consumer) -- for now only `NoOutputConfig` is there.

Let me know if you'll think of improving this somehow. I won't be able to work on this much in the next ten days or so.
