### PR TITLE
Support installing multiple ghc-mod instances

### DIFF
--- a/core/Language/Haskell/GhcMod/Utils.hs
+++ b/core/Language/Haskell/GhcMod/Utils.hs
@@ -76,28 +76,20 @@ newTempDir _dir =
 whenM :: Monad m => m Bool -> m () -> m ()
 whenM mb ma = mb >>= flip when ma
 
--- | Returns the path to the currently running ghc-mod executable. With ghc<7.6
--- this is a guess but >=7.6 uses 'getExecutablePath'.
+-- | Returns the path to the currently running ghc-mod executable.
 ghcModExecutable :: IO FilePath
 ghcModExecutable = do
-    exe <- getExecutablePath'
+    exe <- getExecutablePath
     stack <- lookupEnv "STACK_EXE"
     case takeBaseName exe of
       "spec" | Just _ <- stack ->
-          (</> "ghc-mod") <$> getBinDir
+          (</> "ghc-mod-real") <$> getBinDir
       "spec" ->
-          (</> "dist/build/ghc-mod/ghc-mod") <$> getCurrentDirectory
+          (</> "dist/build/ghc-mod-real/ghc-mod-real") <$> getCurrentDirectory
       "ghc-mod" ->
           return exe
       _ ->
-          return $ takeDirectory exe </> "ghc-mod"
-
-getExecutablePath' :: IO FilePath
-#if __GLASGOW_HASKELL__ >= 706
-getExecutablePath' = getExecutablePath
-#else
-getExecutablePath' = getProgName
-#endif
+          return $ takeDirectory exe </> "ghc-mod-real"
 
 canonFilePath :: FilePath -> IO FilePath
 canonFilePath f = do

--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -213,6 +213,22 @@ Library
 
 Executable ghc-mod
   Default-Language:     Haskell2010
+  Main-Is:              GHCModWrapper.hs
+  Other-Modules:        Paths_ghc_mod
+  HS-Source-Dirs:       ., src, shared
+  GHC-Options:          -Wall
+  Build-Depends:        base      < 5 && >= 4.0
+                      , directory < 1.4
+                      , filepath  < 1.5
+                      , process   < 1.5
+
+                      , deepseq   < 1.5
+                      , binary    < 0.9 && >= 0.5.1.0
+                      , old-time  < 1.2
+                      , time      < 1.7
+
+Executable ghc-mod-real
+  Default-Language:     Haskell2010
   Main-Is:              GHCModMain.hs
   Other-Modules:        Paths_ghc_mod
                       , GHCMod.Options

--- a/src/GHCModWrapper.hs
+++ b/src/GHCModWrapper.hs
@@ -1,0 +1,30 @@
+-- | Dispatcher program to support co-installation of multiple ghc-mod
+-- instances (compiled against different GHC versions) without breaking the
+-- commandline API
+module Main where
+
+import System.IO
+import System.Exit
+import System.Process
+import System.FilePath
+import System.Environment
+import Utils
+
+import Paths_ghc_mod
+
+main :: IO ()
+main = do
+  args <- getArgs
+  libexecdir <- getLibexecDir
+  let installedExe = libexecdir </> "ghc-mod-real"
+  mexe <- mightExist installedExe
+  case mexe of
+    Nothing -> do
+      hPutStrLn stderr $
+        "ghc-mod: Could not find '"++installedExe++"', check your installation!"
+      exitWith $ ExitFailure 1
+
+    Just exe -> do
+      (_, _, _, h) <-
+          createProcess $ proc exe args
+      exitWith =<< waitForProcess h


### PR DESCRIPTION
For #615 

Still need to add support for GHC version autodetection in the new `ghc-mod` wrapper.