### PR TITLE
Fix for "ghc-mod doc Data.Maybe" when used with stack projects

### DIFF
--- a/Language/Haskell/GhcMod/GhcPkg.hs
+++ b/Language/Haskell/GhcMod/GhcPkg.hs
@@ -86,7 +86,7 @@ getPackageDbStack = do
     CabalProject ->
         getCabalPackageDbStack
     (StackProject StackEnv {..}) ->
-        return $ map PackageDb [seSnapshotPkgDb, seLocalPkgDb]
+        return $ [GlobalDb, PackageDb seSnapshotPkgDb, PackageDb seLocalPkgDb]
   return $ fromMaybe stack mCusPkgStack
 
 getPackageCachePaths :: IOish m => FilePath -> GhcModT m [FilePath]


### PR DESCRIPTION
When ghc-pkg is invoked from a stack project the global database is
indeed used:

  $ stack exec -- ghc-pkg find-module Data.Maybe
  /var/lib/ghc/package.conf.d
      base-4.9.0.0
  /home/user/.stack/snapshots/x86_64-linux/lts-7.11/8.0.1/pkgdb
      (no packages)
  /home/user/work/ghc-mod-5.6.0.0/.stack-work/install/x86_64-linux/lts-7.11/8.0.1/pkgdb
      (no packages)

Therefore "ghc-mod doc" should also use GlobalDb