### PR TITLE
Do not log warning when Stack project is preferred

### DIFF
--- a/core/Language/Haskell/GhcMod/Cradle.hs
+++ b/core/Language/Haskell/GhcMod/Cradle.hs
@@ -126,7 +126,7 @@ stackCradle stackProg wdir = do
         mzero
 
       (True, True) -> do
-        gmLog GmWarning "" $ text "STACK_EXE set, preferring Stack project"
+        gmLog GmInfo "" $ text "STACK_EXE set, preferring Stack project"
 
       (True, False) | setupCfgExists -> do
         gmLog GmWarning "" $ text "'dist/setup-config' exists, ignoring Stack project"


### PR DESCRIPTION
When STACK_EXE is set and thus Stack project is used, it doesn't make sense to log a warning about this. 

I think the other 3 cases have a reasonable log level, but this one has to be decreased to the info level.