### PR TITLE
Move exe specific types out of core

### DIFF
--- a/GhcModExe/Boot.hs
+++ b/GhcModExe/Boot.hs
@@ -8,7 +8,7 @@ import GhcModExe.Flag
 import GhcModExe.Lang
 import GhcModExe.Modules
 import Language.Haskell.GhcMod.Monad
-import Language.Haskell.GhcMod.Types (defaultBrowseOpts)
+import Language.Haskell.GhcMod.Types
 
 -- | Printing necessary information for front-end booting.
 boot :: IOish m => GhcModT m String

--- a/GhcModExe/Browse.hs
+++ b/GhcModExe/Browse.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE CPP #-}
 module GhcModExe.Browse (
     browse,
-    BrowseOpts(..)
+    BrowseOpts(..),
+    defaultBrowseOpts
   ) where
 
 import Safe
@@ -167,3 +168,17 @@ removeForAlls' ty (Just (pre, ftype))
 
 showOutputable :: Outputable a => DynFlags -> a -> String
 showOutputable dflag = unwords . lines . showPage dflag styleUnqualified . ppr
+
+data BrowseOpts = BrowseOpts {
+        optBrowseOperators      :: Bool
+        -- ^ If 'True', operators are also returned.
+      , optBrowseDetailed       :: Bool
+        -- ^ If 'True', types are also returned.
+      , optBrowseParents        :: Bool
+        -- ^ If 'True', parents are also returned.
+      , optBrowseQualified      :: Bool
+        -- ^ If 'True', will return fully qualified names
+    } deriving (Show)
+
+defaultBrowseOpts :: BrowseOpts
+defaultBrowseOpts = BrowseOpts False False False False

--- a/GhcModExe/Internal.hs
+++ b/GhcModExe/Internal.hs
@@ -9,7 +9,6 @@ module GhcModExe.Internal (
   , GmEnv(..)
   -- * Various Paths
   , ghcLibDir
-  , ghcModExecutable
   -- * Logging
   , withLogger
   , setNoWarningFlags

--- a/GhcModExe/Lint.hs
+++ b/GhcModExe/Lint.hs
@@ -28,3 +28,13 @@ lint opt file = ghandle handler $
       | srcSpanFilename (ideaSpan idea) == temp
       = idea{ideaSpan=(ideaSpan idea){srcSpanFilename = orig}}
     substFile _ _ idea = idea
+
+-- | Options for "lintWith" function
+data LintOpts = LintOpts {
+        optLintHlintOpts :: [String]
+        -- ^ options that will be passed to hlint executable
+      } deriving (Show)
+
+-- | Default "LintOpts" instance
+defaultLintOpts :: LintOpts
+defaultLintOpts = LintOpts []

--- a/core/Language/Haskell/GhcMod/Types.hs
+++ b/core/Language/Haskell/GhcMod/Types.hs
@@ -373,32 +373,6 @@ instance Binary ChEntrypoint where
     put = ggput . from
     get = to `fmap` ggget
 
--- | Options for "lintWith" function
-data LintOpts = LintOpts {
-        optLintHlintOpts :: [String]
-        -- ^ options that will be passed to hlint executable
-      } deriving (Show)
-
--- | Default "LintOpts" instance
-defaultLintOpts :: LintOpts
-defaultLintOpts = LintOpts []
-
--- | Options for "browseWith" function
-data BrowseOpts = BrowseOpts {
-        optBrowseOperators      :: Bool
-        -- ^ If 'True', "browseWith" also returns operators.
-      , optBrowseDetailed       :: Bool
-        -- ^ If 'True', "browseWith" also returns types.
-      , optBrowseParents        :: Bool
-        -- ^ If 'True', "browseWith" also returns parents.
-      , optBrowseQualified      :: Bool
-        -- ^ If 'True', "browseWith" will return fully qualified name
-    } deriving (Show)
-
--- | Default "BrowseOpts" instance
-defaultBrowseOpts :: BrowseOpts
-defaultBrowseOpts = BrowseOpts False False False False
-
 mkLabel ''GhcModCaches
 mkLabel ''GhcModState
 mkLabel ''Options

--- a/core/Language/Haskell/GhcMod/Utils.hs
+++ b/core/Language/Haskell/GhcMod/Utils.hs
@@ -34,13 +34,10 @@ import Language.Haskell.GhcMod.Error
 import Language.Haskell.GhcMod.Types
 import Language.Haskell.GhcMod.Monad.Types
 import System.Directory
-import System.Environment
 import System.FilePath
 import System.IO.Temp (createTempDirectory)
 import System.Process (readProcess)
-import Text.Printf
 
-import Paths_ghc_mod (getLibexecDir, getBinDir)
 import Utils
 import Prelude
 
@@ -75,29 +72,6 @@ newTempDir _dir =
 
 whenM :: Monad m => m Bool -> m () -> m ()
 whenM mb ma = mb >>= flip when ma
-
--- | Returns the path to the currently running ghc-mod executable. With ghc<7.6
--- this is a guess but >=7.6 uses 'getExecutablePath'.
-ghcModExecutable :: IO FilePath
-ghcModExecutable = do
-    exe <- getExecutablePath'
-    stack <- lookupEnv "STACK_EXE"
-    case takeBaseName exe of
-      "spec" | Just _ <- stack ->
-          (</> "ghc-mod") <$> getBinDir
-      "spec" ->
-          (</> "dist/build/ghc-mod/ghc-mod") <$> getCurrentDirectory
-      "ghc-mod" ->
-          return exe
-      _ ->
-          return $ takeDirectory exe </> "ghc-mod"
-
-getExecutablePath' :: IO FilePath
-#if __GLASGOW_HASKELL__ >= 706
-getExecutablePath' = getExecutablePath
-#else
-getExecutablePath' = getProgName
-#endif
 
 canonFilePath :: FilePath -> IO FilePath
 canonFilePath f = do

--- a/src/GHCMod/Options/Commands.hs
+++ b/src/GHCMod/Options/Commands.hs
@@ -22,10 +22,12 @@ import Data.Semigroup
 import Options.Applicative
 import Options.Applicative.Types
 import Options.Applicative.Builder.Internal
-import Language.Haskell.GhcMod.Types
 import Language.Haskell.GhcMod.Read
 import Language.Haskell.GhcMod.Options.DocUtils
 import Language.Haskell.GhcMod.Options.Help
+
+import GhcModExe.Lint
+import GhcModExe.Browse
 
 type Symbol = String
 type Expr = String

--- a/test/BrowseSpec.hs
+++ b/test/BrowseSpec.hs
@@ -2,6 +2,7 @@ module BrowseSpec where
 
 import Control.Applicative
 import GhcMod
+import GhcModExe.Browse
 import Test.Hspec
 import Prelude
 

--- a/test/FileMappingSpec.hs
+++ b/test/FileMappingSpec.hs
@@ -10,6 +10,7 @@ import System.IO.Temp
 import System.Directory
 
 import GhcMod
+import GhcModExe.Lint
 
 spec :: Spec
 spec = do

--- a/test/LintSpec.hs
+++ b/test/LintSpec.hs
@@ -1,6 +1,6 @@
 module LintSpec where
 
-import GhcMod
+import GhcModExe.Lint
 import Test.Hspec
 import TestUtils
 


### PR DESCRIPTION
[![build status](https://gitlab.com/dxld/ghc-mod/badges/move-exe-specific-types/build.svg
)](https://gitlab.com/dxld/ghc-mod/commits/move-exe-specific-types)

Other candidates:

- `Expression`?
- `ModuleName`?
