### PR TITLE
Better optparse error for unknown commands

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -193,7 +193,7 @@ Library
                       , hlint                < 2.1  && >= 2.0.8
                       , monad-control        < 1.1  && >= 1
                       , monad-journal        < 0.8  && >= 0.4
-                      , optparse-applicative == 0.13.0.*
+                      , optparse-applicative < 0.15 && >= 0.14
                       , pipes                < 4.4  && >= 4.1
                       , safe                 < 0.4  && >= 0.3.9
                       , semigroups           < 0.19 && >= 0.10.0
@@ -233,7 +233,7 @@ Executable ghc-mod
 
                       , fclabels             < 2.1  && >= 2.0
                       , monad-control        < 1.1  && >= 1
-                      , optparse-applicative == 0.13.0.*
+                      , optparse-applicative < 0.15 && >= 0.14
                       , semigroups           < 0.19 && >= 0.10.0
                       , split                < 0.3  && >= 0.2.2
 

--- a/src/GHCMod/Options.hs
+++ b/src/GHCMod/Options.hs
@@ -63,10 +63,10 @@ helpVersion =
     r :: ReadM (a -> a)
     r = do
       v <- readerAsk
-      case v of
-        "help" -> readerAbort ShowHelpText
-        "version" -> readerAbort $ InfoMsg ghcModVersion
-        _ -> return id
+      readerAbort $ case v of
+        "help"    -> ShowHelpText
+        "version" -> InfoMsg ghcModVersion
+        _         -> UnexpectedError v (SomeParser argAndCmdSpec)
 
 argAndCmdSpec :: Parser (Options, GhcModCommands)
 argAndCmdSpec = (,) <$> globalArgSpec <*> commandsSpec


### PR DESCRIPTION
Using `id` for the unknown case was leading to an incorrect error message when there were mistakes in the command name.

With this change one gets an error message like:
```
> ghc-mod brows
Invalid argument `brows'

Did you mean this?
    browse
```