### PR TITLE
file map line pragmas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ elisp/*.elc
 /.cabal-sandbox/
 /.stack-work/
 /test/data/**/stack.yaml
+/test/data/**/.cabal-sandbox/
 add-source-timestamps
 package.cache
 cabal.sandbox.config

--- a/GhcMod/Exe/Info.hs
+++ b/GhcMod/Exe/Info.hs
@@ -20,7 +20,6 @@ import GhcMod.Logging
 import GhcMod.Monad
 import GhcMod.SrcUtils
 import GhcMod.Types
-import GhcMod.Utils (mkRevRedirMapFunc)
 import GhcMod.FileMapping (fileModSummaryWithMapping)
 
 ----------------------------------------------------------------
@@ -42,8 +41,7 @@ info file expr =
 
     body :: (GhcMonad m, GmState m, GmEnv m) => m String
     body = do
-      m <- mkRevRedirMapFunc
-      sdoc  <- Gap.infoThing m expr
+      sdoc  <- Gap.infoThing expr
       st    <- getStyle
       dflag <- G.getSessionDynFlags
       return $ showPage dflag st sdoc

--- a/core/GhcMod/FileMapping.hs
+++ b/core/GhcMod/FileMapping.hs
@@ -63,19 +63,19 @@ loadMappedFileSource from src = do
     hPutStr h src'
     hClose h
     return fn
-  loadMappedFile' from to True
+  loadMappedFile' from to
   where escape (x:xs) = if x `elem` "\\\""
                         then '\\':x:escape xs
                         else x:escape xs
         escape [] = []
 
-loadMappedFile' :: IOish m => FilePath -> FilePath -> Bool -> GhcModT m ()
-loadMappedFile' from to isTemp = do
+loadMappedFile' :: IOish m => FilePath -> FilePath -> GhcModT m ()
+loadMappedFile' from to = do
   cfn <- getCanonicalFileNameSafe from
   unloadMappedFile' cfn
   crdl <- cradle
   let to' = makeRelative (cradleRootDir crdl) to
-  addMMappedFile cfn (FileMapping to' isTemp)
+  addMMappedFile cfn (FileMapping to')
 
 mapFile :: (IOish m, GmState m) => HscEnv -> Target -> m Target
 mapFile _ (Target tid@(TargetFile filePath _) taoc _) = do
@@ -109,7 +109,7 @@ unloadMappedFile = getCanonicalFileNameSafe >=> unloadMappedFile'
 unloadMappedFile' :: IOish m => FilePath -> GhcModT m ()
 unloadMappedFile' cfn = void $ runMaybeT $ do
   fm <- MaybeT $ lookupMMappedFile cfn
-  liftIO $ when (fmTemp fm) $ removeFile (fmPath fm)
+  liftIO $ removeFile (fmPath fm)
   delMMappedFile cfn
 
 fileModSummaryWithMapping :: (IOish m, GmState m, GhcMonad m, GmEnv m) =>

--- a/core/GhcMod/Gap.hs
+++ b/core/GhcMod/Gap.hs
@@ -79,7 +79,6 @@ import SysTools
 import GHCi (stopIServ)
 #endif
 
-import qualified Name
 import qualified InstEnv
 import qualified Pretty
 import qualified StringBuffer as SB
@@ -407,8 +406,8 @@ filterOutChildren get_thing xs
   where
     implicits = mkNameSet [getName t | x <- xs, t <- implicitTyThings (get_thing x)]
 
-infoThing :: GhcMonad m => (FilePath -> FilePath) -> Expression -> m SDoc
-infoThing m (Expression str) = do
+infoThing :: GhcMonad m => Expression -> m SDoc
+infoThing (Expression str) = do
     names <- parseName str
 #if __GLASGOW_HASKELL__ >= 708
     mb_stuffs <- mapM (getInfo False) names
@@ -417,45 +416,30 @@ infoThing m (Expression str) = do
     mb_stuffs <- mapM getInfo names
     let filtered = filterOutChildren (\(t,_f,_i) -> t) (catMaybes mb_stuffs)
 #endif
-    return $ vcat (intersperse (text "") $ map (pprInfo m False) filtered)
+    return $ vcat (intersperse (text "") $ map (pprInfo False) filtered)
 
 #if __GLASGOW_HASKELL__ >= 708
-pprInfo :: (FilePath -> FilePath) -> Bool -> (TyThing, GHC.Fixity, [ClsInst], [FamInst]) -> SDoc
-pprInfo m _ (thing, fixity, insts, famInsts)
-    = pprTyThingInContextLoc' thing
+pprInfo :: Bool -> (TyThing, GHC.Fixity, [ClsInst], [FamInst]) -> SDoc
+pprInfo _ (thing, fixity, insts, famInsts)
+    = pprTyThingInContextLoc thing
    $$ show_fixity fixity
    $$ InstEnv.pprInstances insts
    $$ pprFamInsts famInsts
-#else
-pprInfo :: (FilePath -> FilePath) -> PrintExplicitForalls -> (TyThing, GHC.Fixity, [ClsInst]) -> SDoc
-pprInfo m pefas (thing, fixity, insts)
-    = pprTyThingInContextLoc' pefas thing
-   $$ show_fixity fixity
-   $$ vcat (map pprInstance insts)
-#endif
   where
     show_fixity fx
       | fx == defaultFixity = Outputable.empty
       | otherwise           = ppr fx <+> ppr (getName thing)
-#if __GLASGOW_HASKELL__ >= 708
-    pprTyThingInContextLoc' thing' = hang (pprTyThingInContext thing') 2
-                                        (char '\t' <> ptext (sLit "--") <+> loc)
-                         where loc = ptext (sLit "Defined") <+> pprNameDefnLoc' (getName thing')
 #else
-    pprTyThingInContextLoc' pefas' thing' = hang (pprTyThingInContext pefas' thing') 2
-                                    (char '\t' <> ptext (sLit "--") <+> loc)
-                               where loc = ptext (sLit "Defined") <+> pprNameDefnLoc' (getName thing')
+pprInfo :: PrintExplicitForalls -> (TyThing, GHC.Fixity, [ClsInst]) -> SDoc
+pprInfo pefas (thing, fixity, insts)
+    = pprTyThingInContextLoc pefas thing
+   $$ show_fixity fixity
+   $$ vcat (map pprInstance insts)
+  where
+    show_fixity fx
+      | fx == defaultFixity = Outputable.empty
+      | otherwise           = ppr fx <+> ppr (getName thing)
 #endif
-    pprNameDefnLoc' name
-      = case Name.nameSrcLoc name of
-           RealSrcLoc s -> ptext (sLit "at") <+> ppr (subst s)
-           UnhelpfulLoc s
-             | Name.isInternalName name || Name.isSystemName name
-             -> ptext (sLit "at") <+> ftext s
-             | otherwise
-             -> ptext (sLit "in") <+> quotes (ppr (nameModule name))
-      where subst s = mkRealSrcLoc (realFP s) (srcLocLine s) (srcLocCol s)
-            realFP = mkFastString . m . unpackFS . srcLocFile
 
 ----------------------------------------------------------------
 ----------------------------------------------------------------

--- a/core/GhcMod/Gap.hs
+++ b/core/GhcMod/Gap.hs
@@ -84,10 +84,6 @@ import qualified InstEnv
 import qualified Pretty
 import qualified StringBuffer as SB
 
-#if __GLASGOW_HASKELL__ >= 710
-import CoAxiom (coAxiomTyCon)
-#endif
-
 #if __GLASGOW_HASKELL__ >= 708
 import FamInstEnv
 import ConLike (ConLike(..))
@@ -428,44 +424,28 @@ pprInfo :: (FilePath -> FilePath) -> Bool -> (TyThing, GHC.Fixity, [ClsInst], [F
 pprInfo m _ (thing, fixity, insts, famInsts)
     = pprTyThingInContextLoc' thing
    $$ show_fixity fixity
-   $$ vcat (map pprInstance' insts)
-   $$ vcat (map pprFamInst' famInsts)
+   $$ InstEnv.pprInstances insts
+   $$ pprFamInsts famInsts
 #else
 pprInfo :: (FilePath -> FilePath) -> PrintExplicitForalls -> (TyThing, GHC.Fixity, [ClsInst]) -> SDoc
 pprInfo m pefas (thing, fixity, insts)
     = pprTyThingInContextLoc' pefas thing
    $$ show_fixity fixity
-   $$ vcat (map pprInstance' insts)
+   $$ vcat (map pprInstance insts)
 #endif
   where
     show_fixity fx
       | fx == defaultFixity = Outputable.empty
       | otherwise           = ppr fx <+> ppr (getName thing)
 #if __GLASGOW_HASKELL__ >= 708
-    pprTyThingInContextLoc' thing' = showWithLoc (pprDefinedAt' thing') (pprTyThingInContext thing')
-#if __GLASGOW_HASKELL__ >= 710
-    pprFamInst' (FamInst { fi_flavor = DataFamilyInst rep_tc })
-      = pprTyThingInContextLoc (ATyCon rep_tc)
-
-    pprFamInst' (FamInst { fi_flavor = SynFamilyInst, fi_axiom = axiom
-                        , fi_tys = lhs_tys, fi_rhs = rhs })
-      = showWithLoc (pprDefinedAt' (getName axiom)) $
-        hang (ptext (sLit "type instance") <+> pprTypeApp (coAxiomTyCon axiom) lhs_tys)
-           2 (equals <+> ppr rhs)
+    pprTyThingInContextLoc' thing' = hang (pprTyThingInContext thing') 2
+                                        (char '\t' <> ptext (sLit "--") <+> loc)
+                         where loc = ptext (sLit "Defined") <+> pprNameDefnLoc' (getName thing')
 #else
-    pprFamInst' ispec = showWithLoc (pprDefinedAt' (getName ispec)) (pprFamInstHdr ispec)
+    pprTyThingInContextLoc' pefas' thing' = hang (pprTyThingInContext pefas' thing') 2
+                                    (char '\t' <> ptext (sLit "--") <+> loc)
+                               where loc = ptext (sLit "Defined") <+> pprNameDefnLoc' (getName thing')
 #endif
-#else
-    pprTyThingInContextLoc' pefas' thing' = showWithLoc (pprDefinedAt' thing') (pprTyThingInContext pefas' thing')
-#endif
-    showWithLoc loc doc
-        = hang doc 2 (char '\t' <> comment <+> loc)
-        -- The tab tries to make them line up a bit
-      where
-        comment = ptext (sLit "--")
-    pprInstance' ispec = hang (pprInstanceHdr ispec)
-        2 (ptext (sLit "--") <+> pprDefinedAt' (getName ispec))
-    pprDefinedAt' thing' = ptext (sLit "Defined") <+> pprNameDefnLoc' (getName thing')
     pprNameDefnLoc' name
       = case Name.nameSrcLoc name of
            RealSrcLoc s -> ptext (sLit "at") <+> ppr (subst s)

--- a/core/GhcMod/Types.hs
+++ b/core/GhcMod/Types.hs
@@ -70,7 +70,7 @@ data OutputStyle = LispStyle  -- ^ S expression style.
 -- | The type for line separator. Historically, a Null string is used.
 newtype LineSeparator = LineSeparator String deriving (Show)
 
-data FileMapping =  FileMapping {fmPath :: FilePath, fmTemp :: Bool}
+newtype FileMapping =  FileMapping {fmPath :: FilePath}
                   deriving (Eq, Show)
 
 type FileMappingMap = Map FilePath FileMapping

--- a/core/GhcMod/Utils.hs
+++ b/core/GhcMod/Utils.hs
@@ -128,18 +128,6 @@ getCanonicalFileNameSafe fn = do
     splitPath' = splitPath
 #endif
 
-mkRevRedirMapFunc :: (Functor m, GmState m, GmEnv m) => m (FilePath -> FilePath)
-mkRevRedirMapFunc = do
-  rm <- M.fromList <$> map (uncurry mf) <$> M.toList <$> getMMappedFiles
-  crdl <- cradle
-  return $ \key ->
-    fromMaybe key
-    $ makeRelative (cradleRootDir crdl)
-    <$> M.lookup key rm
-  where
-    mf :: FilePath -> FileMapping -> (FilePath, FilePath)
-    mf from to = (fmPath to, from)
-
 findFilesWith' :: (FilePath -> IO Bool) -> [FilePath] -> String -> IO [FilePath]
 findFilesWith' _ [] _ = return []
 findFilesWith' f (d:ds) fileName = do

--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -323,7 +323,7 @@ Test-Suite spec
 
                       , base                 < 4.10 && >= 4.6.0.1
                       , fclabels             < 2.1  && >= 2.0
-                      , hspec                < 2.4  && >= 2.0.0
+                      , hspec                < 2.5  && >= 2.0.0
                       , monad-journal        < 0.8  && >= 0.4
                       , split                < 0.3  && >= 0.2.2
                       , temporary            < 1.3  && >= 1.2.0.3

--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -202,6 +202,7 @@ Library
                       , temporary            < 1.3  && >= 1.2.0.3
                       , text                 < 1.3  && >= 1.2.1.3
                       , transformers-base    < 0.5  && >= 0.4.4
+                      , cpphs                >= 1.18 && < 1.21
 
                       , cabal-helper         < 0.8  && >= 0.7.3.0
                       , ghc                  < 8.2  && >= 7.6


### PR DESCRIPTION
This turned out a bit more messy than I would like due to Literate Haskell files. That said, still better than the mess we have currently I guess?

Updated tests pass on my machine, but I didn't check on anything but GHC 8.0.

/cc @wz1000 -- I believe this was your idea?

NOTE: As of now, this introduces a behavior change. Mapped files specified with file path are handled as temp.files now, which means **changes made to redirected files made after initial load are not visible to ghc-mod**. Not sure if anyone relied on earlier behavior. Should be possible to reload those each time they're needed, but that's a bit of an overhead. Feedback from someone actually using file redirection (as opposed to loading from memory/stdin) would be appreciated. @voanhduy1512?