### PR TITLE
Add a check for shelltest flag

### DIFF
--- a/ghc-mod.cabal
+++ b/ghc-mod.cabal
@@ -345,7 +345,8 @@ Test-Suite shelltest
   Main-Is:              ShellTest.hs
   Hs-Source-Dirs:       shelltest
   Type:                 exitcode-stdio-1.0
-  Build-Tools:          shelltest
+  if flag(shelltest)
+    Build-Tools:        shelltest
   Build-Depends:        base                 < 4.10 && >= 4.6.0.1
                       , process              < 1.5
                       -- , shelltestrunner >= 1.3.5


### PR DESCRIPTION
Without this additional flag check the `shelltest` build tool is always a dependency.
This was an issue for me when using `nix` to build `ghc-mod` via the `cabal2nix` utility as it then depends on `shelltest` regardless of the value of the flag.