### PR TITLE
Update for GHC 8.2.x

### DIFF
--- a/core/GhcMod/Types.hs
+++ b/core/GhcMod/Types.hs
@@ -284,7 +284,6 @@ data GmComponentType = GMCRaw
                      | GMCResolved
 data GmComponent (t :: GmComponentType) eps = GmComponent {
     gmcHomeModuleGraph :: GmModuleGraph
-  , gmcName            :: ChComponentName
   , gmcGhcOpts         :: [GHCOption]
   , gmcGhcPkgOpts      :: [GHCOption]
   , gmcGhcSrcOpts      :: [GHCOption]
@@ -292,6 +291,7 @@ data GmComponent (t :: GmComponentType) eps = GmComponent {
   , gmcRawEntrypoints  :: ChEntrypoint
   , gmcEntrypoints     :: eps
   , gmcSourceDirs      :: [FilePath]
+  , gmcName            :: ChComponentName  
   } deriving (Eq, Ord, Show, Read, Generic, Functor)
 
 instance Binary eps => Binary (GmComponent t eps) where


### PR DESCRIPTION
Hi,
as an extension of the work in PR #911 working on issue #900 for supporting GHC 8.2.x, I have made some small, almost mechanical changes. 
These changes in combination with the current `cabal-helper:master` (DanielG/cabal-helper@4bfc6b916fcc696a5d82e7cd35713d6eabcb0533) yield a working ghc-mod for GHC 8.2.2, which I have been using for a few weeks now, via the atom plugin.